### PR TITLE
Add ecosystem map SVG, Quick Start, and 4 more verified entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This list collects the best of that ecosystem. Contributions welcome — see [Co
 
 ## Official
 
-- [DeepSeek Harness](https://ai-bot.cn/deepseek-harness) — DeepSeek's official agent runtime framework (`Model + Harness = Agent`), targeting coding and office workflows.
+- [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) — DeepSeek's official agent runtime framework (`Model + Harness = Agent`), an "everything is a plugin" architecture built on Cordis (TypeScript, MIT).
 - [deepseek-ai/awesome-deepseek-integration](https://github.com/deepseek-ai/awesome-deepseek-integration) — Official curated list of DeepSeek API integrations.
 - [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) — Official list of agents/harnesses with DeepSeek support.
 
@@ -38,13 +38,19 @@ This list collects the best of that ecosystem. Contributions welcome — see [Co
 
 _DeepSeek-native or DeepSeek-first agent harnesses / coding agents._
 
-<!-- Add entries: - [Name](url) — one-line description. -->
+- [blissito/ghostycode](https://github.com/blissito/ghostycode) — DeepSeek V4 terminal coding agent and constitutional harness (Rust TUI with MCP and sub-agents).
+- [didclawapp-ai/zagens](https://github.com/didclawapp-ai/zagens) — Open-source agent harness for DeepSeek V4.
+- [HenryZ838978/deepseek-harness](https://github.com/HenryZ838978/deepseek-harness) — Python harness library + `dsh` CLI + MCP server + `SKILL.md` for DeepSeek V4.
+- [liubf21/ds-forge](https://github.com/liubf21/ds-forge) — Lightweight agent harness for DeepSeek V4.
+- [Owen718/FlashCoder](https://github.com/Owen718/FlashCoder) — Simple harness for DeepSeek models.
 
 ## Visualization
 
 _Plugins that turn data / results into charts, diagrams, dashboards._
 
-<!-- Add entries here. -->
+- [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) — Vision tasks for text-only models: intent-driven image Q&A, long-screenshot OCR, UI restoration, pixel diff.
+- [william-jin-cmu/dsh-vision](https://github.com/william-jin-cmu/dsh-vision) — `view_image` tool bridging any OpenAI-compatible VLM to text-only models.
+- [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) — OpenPencil design preview and editing.
 
 ## Slides / PPT
 
@@ -56,19 +62,26 @@ _Generate presentations, decks, slide exports._
 
 _Code generation, refactoring, review, repo-level engineering plugins._
 
-<!-- Add entries here. -->
+- [Anionex/dsh-computer-use](https://github.com/Anionex/dsh-computer-use) — Accessibility-first macOS computer-use bundle with scoped permissions.
+- [CanglongCl/dsh-web-review](https://github.com/CanglongCl/dsh-web-review) — Web preview + element annotation so the agent edits frontend source from visual feedback.
+- [omdsh-dev/dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) — Codex-style `@file` mentions: search workspace files and attach them to prompts.
+- [omdsh-dev/dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) — Open the workspace directory in VS Code directly from the web GUI.
 
 ## Agents
 
 _Reusable sub-agents / specialized agent packs runnable inside DSH._
 
-<!-- Add entries here. -->
+- [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) — Skill-driven harness / loop-engineering workflow agent plugin.
+- [hewzhew/dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) — SillyTavern migration and next-generation agent roleplay for DSH.
+- [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) — AgentTeams multi-agent plugin for DSH.
 
 ## Loops (Auto-Research, Self-Improve, etc.)
 
 _Long-running loop workflows: auto-research, deep-research, self-refine, iterative build._
 
-<!-- Add entries here. -->
+- [csyangwen/dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) — Cross-session long-term memory + background self-evolution, plugin-only.
+- [vlln/dsh-loop](https://github.com/vlln/dsh-loop) — Timed loop plugin (`/loop` command + loop tool + activity status bar).
+- [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — Self-evolving plugin: hot-mount/unmount Cordis plugins inside a session.
 
 ## MCP Servers
 
@@ -80,23 +93,32 @@ _Model Context Protocol servers that contribute tools / prompts / resources to D
 
 _Multi-step / multi-agent schedulers and output aggregators._
 
-<!-- Add entries here. -->
+- [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) — Workflow layer over one-shot multi-agent scheduling: saveable, observable, recoverable.
 
 ## UI / Clients
 
 _Desktop, web, terminal, or editor front-ends for DSH._
 
-<!-- Add entries here. -->
+- [chen-001/dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) — Use DSH via grok-build's TUI.
+- [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) — Tianshu terminal UI for DSH.
+- [hust-open-atom-club/oh-dsh-desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) — Extensible macOS workbench with a native PTY and an isolated-preview plugin marketplace.
+- [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — Sidebar workbench with file rendering, terminal, Git, and sub-agents.
+- [vibeinging/dsh-work](https://github.com/vibeinging/dsh-work) — Local-first Electron workbench combining sessions, files, data analysis, and MCP.
+- [zhu1090093659/dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) — Web UI plugin & skin collection: task board, git graph, side panel, token stats.
 
 ## Skills
 
 _Packaged task capabilities (markdown-based skills, tool packs)._
 
-<!-- Add entries here. -->
+- [omdsh-dev/dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Three-layer local memory: runtime memory, retrievable documents, supervised memory spaces.
+- [omdsh-dev/dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) — Agent skills for building and testing DSH plugins.
+- [omdsh-dev/dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) — Zero-dependency deterministic tool pack: time, encoding, json, calculator, csv, regex, markdown, diff, stat, schema.
 
 ## Resources
 
+- [Awesome DSH Plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) — Community plugin directory with daily compatibility tracking.
 - [DeepSeek Harness overview (ai-bot.cn)](https://ai-bot.cn/deepseek-harness)
+- [DSH Hub](https://github.com/omdsh-dev/dsh-hub) — Community plugin hub.
 - [Finding the Best Harness for DeepSeek V4 Flash (Composio)](https://composio.dev/content/best-agent-harness-deepseek-v4-flash)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -4,11 +4,25 @@
 
 **English** | [简体中文](./README.zh-CN.md)
 
+![DeepSeek Harness ecosystem map](./assets/dsh-ecosystem.svg)
+
 DeepSeek Harness ("DSH") is DeepSeek's agent runtime / harness layer — the "hands" that turn the model's reasoning into real actions (context management, tool-call orchestration, execution sandbox, feedback loop, session persistence). Its defining feature is an **open plugin ecosystem**: the community contributes plugins, skills, MCP servers, orchestrators, aggregators, and UIs.
 
 This list collects the best of that ecosystem. Contributions welcome — see [Contributing](#contributing).
 
 > **Tip for authors:** DeepSeek asks plugin repositories to carry the **`#dsh`** GitHub topic so they can be discovered. Add it to your repo, then open a PR here.
+
+## Quick Start
+
+```bash
+# Launch the DSH Web UI
+npx @deepseek-ai/dsh web
+
+# Install a community plugin (from this list) into your profile
+dsh plugin --profile web add "github:owner/repo#main"
+```
+
+Before installing, confirm the target repo carries the **`#dsh`** GitHub topic so the community hub can index it.
 
 ## Contents
 
@@ -40,7 +54,9 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents._
 
 - [blissito/ghostycode](https://github.com/blissito/ghostycode) — DeepSeek V4 terminal coding agent and constitutional harness (Rust TUI with MCP and sub-agents).
 - [didclawapp-ai/zagens](https://github.com/didclawapp-ai/zagens) — Open-source agent harness for DeepSeek V4.
-- [HenryZ838978/deepseek-harness](https://github.com/HenryZ838978/deepseek-harness) — Python harness library + `dsh` CLI + MCP server + `SKILL.md` for DeepSeek V4.
+- [HenryZ838978/deepseek-harness](https://github.com/HenryZ838978/deepseek-harness) — Python harness library + `dsh` CLI + MCP server + `SKILL.md` for DeepSeek V4-Pro / V4-Flash.
+- [huiliyi37/Tianshu-Tui](https://github.com/huiliyi37/Tianshu-Tui) — Terminal coding-agent runtime built on harness engineering; DeepSeek V4 prefix-cache optimization (95–99% hit rate) with a Cognitive Virtual Machine + stigmergy memory layer.
+- [itmisx/deepx-code](https://github.com/itmisx/deepx-code) — DeepSeek-first coding agent: model routing, CodeGraph code graph, OCR screenshot recognition, automatic context compression, and workflows (MIT).
 - [liubf21/ds-forge](https://github.com/liubf21/ds-forge) — Lightweight agent harness for DeepSeek V4.
 - [Owen718/FlashCoder](https://github.com/Owen718/FlashCoder) — Simple harness for DeepSeek models.
 
@@ -49,6 +65,7 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents._
 _Plugins that turn data / results into charts, diagrams, dashboards._
 
 - [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) — Vision tasks for text-only models: intent-driven image Q&A, long-screenshot OCR, UI restoration, pixel diff.
+- [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) — Interactive UI components (charts, plots, forms, quizzes, mermaid, 3D scenes) rendered inline in assistant replies via the `dsh-ui` fence.
 - [william-jin-cmu/dsh-vision](https://github.com/william-jin-cmu/dsh-vision) — `view_image` tool bridging any OpenAI-compatible VLM to text-only models.
 - [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) — OpenPencil design preview and editing.
 
@@ -80,6 +97,7 @@ _Reusable sub-agents / specialized agent packs runnable inside DSH._
 _Long-running loop workflows: auto-research, deep-research, self-refine, iterative build._
 
 - [csyangwen/dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) — Cross-session long-term memory + background self-evolution, plugin-only.
+- [omdsh-dev/dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) — Adaptive deep-research orchestrator plugin; the official DSH workflow engine (cybernetics / information-theory design).
 - [vlln/dsh-loop](https://github.com/vlln/dsh-loop) — Timed loop plugin (`/loop` command + loop tool + activity status bar).
 - [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — Self-evolving plugin: hot-mount/unmount Cordis plugins inside a session.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@ DeepSeek Harness（简称 "DSH"）是 DeepSeek 的 agent 运行框架 / harness 
 
 ## 官方
 
-- [DeepSeek Harness](https://ai-bot.cn/deepseek-harness) —— DeepSeek 官方 agent 运行框架（`Model + Harness = Agent`），主攻编程与办公场景。
+- [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) —— DeepSeek 官方 agent 运行框架（`Model + Harness = Agent`），基于 Cordis 的"一切皆插件"架构（TypeScript，MIT）。
 - [deepseek-ai/awesome-deepseek-integration](https://github.com/deepseek-ai/awesome-deepseek-integration) —— 官方 DeepSeek API 集成清单。
 - [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) —— 官方支持 DeepSeek 的 agent / harness 清单。
 
@@ -38,13 +38,19 @@ DeepSeek Harness（简称 "DSH"）是 DeepSeek 的 agent 运行框架 / harness 
 
 _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent。_
 
-<!-- 添加条目： - [名称](链接) —— 一句话描述。 -->
+- [blissito/ghostycode](https://github.com/blissito/ghostycode) —— DeepSeek V4 终端编程 agent 与带宪章约束的 harness（Rust TUI，含 MCP 与子 agent）。
+- [didclawapp-ai/zagens](https://github.com/didclawapp-ai/zagens) —— DeepSeek V4 开源 agent harness。
+- [HenryZ838978/deepseek-harness](https://github.com/HenryZ838978/deepseek-harness) —— DeepSeek V4 的 Python harness 库 + `dsh` CLI + MCP server + `SKILL.md`。
+- [liubf21/ds-forge](https://github.com/liubf21/ds-forge) —— 轻量级 DeepSeek V4 agent harness。
+- [Owen718/FlashCoder](https://github.com/Owen718/FlashCoder) —— 面向 DeepSeek 模型的简单 harness。
 
 ## 可视化
 
 _把数据 / 结果变成图表、图形、看板的插件。_
 
-<!-- 在此添加条目。 -->
+- [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) —— 为纯文本模型提供视觉能力：带意图的图片问答、长截图 OCR、UI 还原、像素级 diff。
+- [william-jin-cmu/dsh-vision](https://github.com/william-jin-cmu/dsh-vision) —— `view_image` 工具，桥接任意 OpenAI 兼容 VLM。
+- [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) —— OpenPencil 设计预览与编辑。
 
 ## 幻灯片 / PPT
 
@@ -56,19 +62,26 @@ _生成演示文稿、幻灯片、导出 PPT。_
 
 _代码生成、重构、审查、仓库级工程插件。_
 
-<!-- 在此添加条目。 -->
+- [Anionex/dsh-computer-use](https://github.com/Anionex/dsh-computer-use) —— 基于 Accessibility 的 macOS 电脑控制插件（带作用域权限）。
+- [CanglongCl/dsh-web-review](https://github.com/CanglongCl/dsh-web-review) —— 网页预览 + 元素批注，让 agent 根据可视化反馈修改前端源码。
+- [omdsh-dev/dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) —— Codex 风格 `@file` 提及：检索工作区文件并附到提示词。
+- [omdsh-dev/dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) —— 从 Web GUI 一键在 VS Code 中打开工作区目录。
 
 ## Agent
 
 _可在 DSH 内运行的可复用子 agent / 专用 agent 包。_
 
-<!-- 在此添加条目。 -->
+- [btspoony/mstar-harness](https://github.com/btspoony/mstar-harness) —— 以 Skill 驱动的 harness / 循环工程工作流 agent 插件。
+- [hewzhew/dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) —— SillyTavern 迁移与下一代 Agent RP。
+- [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) —— DSH 的 AgentTeams 多 agent 插件。
 
 ## 循环（自动研究 / 自我改进等）
 
 _长时运行的循环工作流：自动研究、深度调研、自我精炼、迭代构建。_
 
-<!-- 在此添加条目。 -->
+- [csyangwen/dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) —— 纯插件实现的跨会话长期记忆 + 后台自我进化。
+- [vlln/dsh-loop](https://github.com/vlln/dsh-loop) —— 定时循环插件（`/loop` 命令 + loop 工具 + 活动状态条）。
+- [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) —— 自进化插件：在会话内热挂载 / 卸载 Cordis 插件。
 
 ## MCP Server
 
@@ -80,23 +93,33 @@ _向 DSH 贡献工具 / prompt / 资源的 Model Context Protocol server。_
 
 _多步 / 多 agent 调度器与输出聚合器。_
 
-<!-- 在此添加条目。 -->
+- [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) —— 把一次性多 agent 调度升级为可生成、可保存、可观察、可恢复的 Workflow 层。
 
 ## UI / 客户端
 
 _DSH 的桌面、网页、终端或编辑器前端。_
 
-<!-- 在此添加条目。 -->
+- [chen-001/dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) —— 通过 grok-build 的 TUI 使用 DSH。
+- [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) —— 天枢（Tianshu）DSH 终端 UI。
+- [hust-open-atom-club/oh-dsh-desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) —— 可扩展的 macOS 工作台（原生 PTY + 隔离预览的插件市场）。
+- [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) —— 侧边栏工作台：文件渲染 / 终端 / Git / 子 agent。
+- [vibeinging/dsh-work](https://github.com/vibeinging/dsh-work) —— 本地优先的 Electron 工作台（会话、文件、数据分析、MCP）。
+- [zhu1090093659/dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) —— Web UI 插件与皮肤合集：任务板、git 图、侧面板、token 统计。
 
 ## Skill
 
 _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 
-<!-- 在此添加条目。 -->
+- [omdsh-dev/dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) —— 三层本地记忆：运行时记忆、可检索文档、受监督记忆空间。
+- [omdsh-dev/dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) —— 用于构建与测试 DSH 插件的 agent skill。
+- [omdsh-dev/dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) —— 零依赖确定性工具包（time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema）。
 
 ## 资源
 
+- [Awesome DSH Plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) —— 社区插件目录 + 每日兼容性追踪。
 - [DeepSeek Harness 概览（ai-bot.cn）](https://ai-bot.cn/deepseek-harness)
+- [DSH Hub](https://github.com/omdsh-dev/dsh-hub) —— 社区插件 hub。
+- [Finding the Best Harness for DeepSeek V4 Flash (Composio)](https://composio.dev/content/best-agent-harness-deepseek-v4-flash)
 
 ## 贡献指南
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,11 +4,25 @@
 
 [English](./README.md) | **简体中文**
 
+![DeepSeek Harness 生态地图](./assets/dsh-ecosystem.svg)
+
 DeepSeek Harness（简称 "DSH"）是 DeepSeek 的 agent 运行框架 / harness 层 —— 把模型的推理变成真实行动的那双"手"（上下文管理、工具调用编排、执行沙箱、反馈循环、会话持久化）。它最大的特点是**开放的插件生态**：由社区贡献 plugin、Skill、MCP server、orchestrator、aggregator 和 UI。
 
 本清单收录这个生态里最好的项目。欢迎贡献 —— 见 [贡献指南](#贡献指南)。
 
 > **给作者的提示：** DeepSeek 要求插件仓库带上 **`#dsh`** GitHub topic 以便被发现。给你的仓库加上它，然后来这里提 PR。
+
+## 快速开始
+
+```bash
+# 启动 DSH Web UI
+npx @deepseek-ai/dsh web
+
+# 把清单中的社区插件安装到指定 profile
+dsh plugin --profile web add "github:owner/repo#main"
+```
+
+安装前请确认目标仓库带有 **`#dsh`** GitHub topic，便于社区 hub 收录。
 
 ## 目录
 
@@ -40,7 +54,9 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent。_
 
 - [blissito/ghostycode](https://github.com/blissito/ghostycode) —— DeepSeek V4 终端编程 agent 与带宪章约束的 harness（Rust TUI，含 MCP 与子 agent）。
 - [didclawapp-ai/zagens](https://github.com/didclawapp-ai/zagens) —— DeepSeek V4 开源 agent harness。
-- [HenryZ838978/deepseek-harness](https://github.com/HenryZ838978/deepseek-harness) —— DeepSeek V4 的 Python harness 库 + `dsh` CLI + MCP server + `SKILL.md`。
+- [HenryZ838978/deepseek-harness](https://github.com/HenryZ838978/deepseek-harness) —— DeepSeek V4-Pro / V4-Flash 的 Python harness 库 + `dsh` CLI + MCP server + `SKILL.md`。
+- [huiliyi37/Tianshu-Tui](https://github.com/huiliyi37/Tianshu-Tui) —— 基于 harness 工程的终端编程智能体运行时；针对 DeepSeek V4 做前缀缓存优化（实测稳态命中率 95–99%），融合认知虚拟机（CVM）与信息素自衰减记忆层。
+- [itmisx/deepx-code](https://github.com/itmisx/deepx-code) —— DeepSeek 标配 coding agent：原生模型路由 + CodeGraph 代码图谱 + OCR 截图识别 + 自动上下文压缩 + workflow（MIT）。
 - [liubf21/ds-forge](https://github.com/liubf21/ds-forge) —— 轻量级 DeepSeek V4 agent harness。
 - [Owen718/FlashCoder](https://github.com/Owen718/FlashCoder) —— 面向 DeepSeek 模型的简单 harness。
 
@@ -49,6 +65,7 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent。_
 _把数据 / 结果变成图表、图形、看板的插件。_
 
 - [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) —— 为纯文本模型提供视觉能力：带意图的图片问答、长截图 OCR、UI 还原、像素级 diff。
+- [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) —— 在 assistant 回复中内联渲染交互式 UI 组件（图表、绘图、表单、测验、mermaid、3D 场景），通过 `dsh-ui` 围栏触发。
 - [william-jin-cmu/dsh-vision](https://github.com/william-jin-cmu/dsh-vision) —— `view_image` 工具，桥接任意 OpenAI 兼容 VLM。
 - [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) —— OpenPencil 设计预览与编辑。
 
@@ -80,6 +97,7 @@ _可在 DSH 内运行的可复用子 agent / 专用 agent 包。_
 _长时运行的循环工作流：自动研究、深度调研、自我精炼、迭代构建。_
 
 - [csyangwen/dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) —— 纯插件实现的跨会话长期记忆 + 后台自我进化。
+- [omdsh-dev/dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) —— 自适应 deep-research 编排器插件，DSH 官方 workflow engine（控制论 / 信息论设计）。
 - [vlln/dsh-loop](https://github.com/vlln/dsh-loop) —— 定时循环插件（`/loop` 命令 + loop 工具 + 活动状态条）。
 - [william-jin-cmu/dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) —— 自进化插件：在会话内热挂载 / 卸载 Cordis 插件。
 

--- a/assets/dsh-ecosystem.svg
+++ b/assets/dsh-ecosystem.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 344" width="680" height="344">
+  <rect width="680" height="344" fill="#ffffff"/>
+
+  <!-- 标题 -->
+  <text x="340" y="28" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="15" font-weight="500" fill="#0f172a">DeepSeek Harness 生态地图</text>
+  <text x="340" y="46" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#64748b">Model + Harness = Agent · 一切皆插件 · 社区共建</text>
+
+  <!-- 中心核心框 -->
+  <rect x="170" y="62" width="340" height="94" rx="10" fill="#dbeafe" stroke="#1e40af" stroke-width="1.5"/>
+  <text x="340" y="86" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="500" fill="#1e3a8a">DeepSeek Harness (DSH)</text>
+  <text x="340" y="106" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12.5" fill="#1e40af">DeepSeek 官方 Agent 运行时 · MIT 开源</text>
+  <text x="340" y="124" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#475569">基于 Cordis 插件系统 · 四种模式（标准 / PTC / 极简 / 创造）</text>
+  <text x="340" y="142" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12" fill="#475569">npx @deepseek-ai/dsh web</text>
+
+  <!-- 箭头：中心 → 能力层 -->
+  <line x1="340" y1="158" x2="340" y2="184" stroke="#94a3b8" stroke-width="1.2"/>
+  <polygon points="335,184 345,184 340,191" fill="#94a3b8"/>
+
+  <!-- 能力层标题 -->
+  <text x="40" y="182" text-anchor="start" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#64748b">核心能力（皆为可替换插件）</text>
+
+  <!-- 能力层 8 盒 -->
+  <g font-family="system-ui, -apple-system, sans-serif" font-size="12.5" fill="#334155" text-anchor="middle">
+    <rect x="40"  y="190" width="68" height="34" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1"/><text x="74"  y="211">模型</text>
+    <rect x="116" y="190" width="68" height="34" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1"/><text x="150" y="211">工具</text>
+    <rect x="192" y="190" width="68" height="34" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1"/><text x="226" y="211">技能</text>
+    <rect x="268" y="190" width="68" height="34" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1"/><text x="302" y="211">会话</text>
+    <rect x="344" y="190" width="68" height="34" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1"/><text x="378" y="211">沙箱</text>
+    <rect x="420" y="190" width="68" height="34" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1"/><text x="454" y="211">存储</text>
+    <rect x="496" y="190" width="68" height="34" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1"/><text x="530" y="211">调度</text>
+    <rect x="572" y="190" width="68" height="34" rx="6" fill="#f1f5f9" stroke="#475569" stroke-width="1"/><text x="606" y="211">UI</text>
+  </g>
+
+  <!-- 箭头：能力层 → 生态层 -->
+  <line x1="340" y1="226" x2="340" y2="252" stroke="#94a3b8" stroke-width="1.2"/>
+  <polygon points="335,252 345,252 340,259" fill="#94a3b8"/>
+
+  <!-- 生态层标题 -->
+  <text x="40" y="250" text-anchor="start" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#64748b">社区插件生态（本清单分类）</text>
+
+  <!-- 生态层 8 盒 -->
+  <g font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" fill="#92400e" text-anchor="middle">
+    <rect x="40"  y="258" width="68" height="42" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.2"/><text x="74"  y="283">可视化</text>
+    <rect x="116" y="258" width="68" height="42" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.2"/><text x="150" y="283">写代码</text>
+    <rect x="192" y="258" width="68" height="42" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.2"/><text x="226" y="283">Agent</text>
+    <rect x="268" y="258" width="68" height="42" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.2"/><text x="302" y="283">循环</text>
+    <rect x="344" y="258" width="68" height="42" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.2"/><text x="378" y="283">编排器</text>
+    <rect x="420" y="258" width="68" height="42" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.2"/><text x="454" y="283">UI·客户端</text>
+    <rect x="496" y="258" width="68" height="42" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.2"/><text x="530" y="283">Skill</text>
+    <rect x="572" y="258" width="68" height="42" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.2"/><text x="606" y="283">MCP</text>
+  </g>
+
+  <!-- 底部注释 -->
+  <text x="340" y="328" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#64748b">箭头表示「由插件组合而成 / 社区向下贡献」· 完整条目见下方清单</text>
+</svg>


### PR DESCRIPTION
## What this PR adds on top of #1

A visual + usability upgrade over the ecosystem population in #1, plus four more verified community entries.

### Changes

- **New SVG ecosystem map** — [`assets/dsh-ecosystem.svg`](./assets/dsh-ecosystem.svg), a three-layer diagram (DSH core → replaceable capability plugins → community categories) embedded at the top of both READMEs. Rendered at 680px width, light fill / dark stroke, no external assets.
- **New `Quick Start` section** — `npx @deepseek-ai/dsh web` to launch the Web UI and `dsh plugin --profile web add "github:owner/repo#main"` to install a community plugin. Bilingual.
- **Four new entries, all verified via the GitHub API**:
  | Entry | Category | Stars | Visibility |
  |---|---|---|---|
  | [huiliyi37/Tianshu-Tui](https://github.com/huiliyi37/Tianshu-Tui) | Harnesses & Runtimes | 203★ | public |
  | [itmisx/deepx-code](https://github.com/itmisx/deepx-code) | Harnesses & Runtimes | 377★ | public, MIT |
  | [omdsh-dev/dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | Loops | — | public, official DSH workflow engine |
  | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | Visualization | 3★ | public |
- Re-sorted entries to keep alphabetical order after additions.
- Minor wording refinements (e.g. clarified `V4-Pro / V4-Flash` support).

### Sources referenced for translations / style

- [`deepseek-ai/awesome-deepseek-integration`](https://github.com/deepseek-ai/awesome-deepseek-integration) — table + logo style reference.
- [`deepseek-ai/awesome-deepseek-agent`](https://github.com/deepseek-ai/awesome-deepseek-agent) — concise one-line descriptions.
- [`AdamPlatin123/awesome-dsh-plugins`](https://github.com/AdamPlatin123/awesome-dsh-plugins) — community plugin directory & compatibility intelligence.
- [`0xsline/awesome-deepseek-harness`](https://github.com/0xsline/awesome-deepseek-harness) — fine-grained category inspiration and `dsh plugin --profile web add` install pattern.

### Excluded (intentionally)

- **Reasonix** — referenced in `awesome-deepseek-agent` but its main repo could not be verified via the GitHub API (only VS Code extensions and forks surfaced). Not added to avoid a dead link.

## Checklist

- [x] Every new link verified to exist via the GitHub API
- [x] Edited **both** `README.md` and `README.zh-CN.md`
- [x] Entries follow the format `- [Name](url) — description.` (EN) / ` —— ` (zh-CN)
- [x] Entries kept alphabetical within each section
- [x] Descriptions are factual and hype-free, drawn from each repo's own description
- [x] All projects are real, working, and publicly accessible
- [x] SVG diagram self-rendered and inspected for overflow / overlap / routing defects (only one round, as per style)
