### PR TITLE
docs: add Code2Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ _Generate presentations, decks, slide exports._
 
 _Code generation, refactoring, review, repo-level engineering plugins._
 
+- [Code2Skill](https://github.com/leechen298/Code2Skill) — Generates Function, MCP, Agent Skill, and offline-test packages from authorized existing code, and ships a DeepSeek Harness bundle for its generation and review skills.
 - [omdsh-dev/dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) — Open DSH workspace directories in VS Code directly from the web GUI.  `⭐33`
 - [omdsh-dev/dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) — Create and manage sandboxed JavaScript tools with a Monaco editor and a model-driven tool lifecycle.  `⭐18`
 - [CanglongCl/dsh-web-review](https://github.com/CanglongCl/dsh-web-review) — Web preview and element annotation for the DSH Web GUI, letting the AI edit front-end source code from visual feedback.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -296,6 +296,7 @@ _生成演示文稿、幻灯片、导出 PPT。_
 
 _代码生成、重构、审查、仓库级工程插件。_
 
+- [Code2Skill](https://github.com/leechen298/Code2Skill) —— 从用户授权的现有代码生成 Function、MCP、Agent Skill 与离线测试包，并提供包含生成与审核 Skill 的 DeepSeek Harness Bundle。
 - [omdsh-dev/dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) —— 从 Web GUI 直接在 VS Code 中打开 DSH 工作区目录。  `⭐33`
 - [omdsh-dev/dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) —— 用 Monaco 编辑器创建和管理沙箱化 JavaScript 工具，工具生命周期由模型驱动。  `⭐18`
 - [CanglongCl/dsh-web-review](https://github.com/CanglongCl/dsh-web-review) —— DSH Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。


### PR DESCRIPTION
## What are you adding?

- **Name:** Code2Skill
- **Link:** https://github.com/leechen298/Code2Skill
- **Category:** Coding / 写代码
- **One-line description:** Generates Function, MCP, Agent Skill, and offline-test packages from authorized existing code, with a DeepSeek Harness bundle for its generation and review skills.

## Checklist

- [x] The repo carries the `#dsh` GitHub topic
- [x] I edited **both** `README.md` and `README.zh-CN.md`
- [x] Entry follows the requested one-line format
- [x] Description is factual and hype-free
- [x] The project is public, working, and released as [v1.1.3](https://github.com/leechen298/Code2Skill/releases/tag/v1.1.3)

## Validation

- `git diff --check`
- Only the bilingual Code2Skill entries were added.
