### PR TITLE
docs: 更新 dsh-chat-import 收录描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [lhh010/dsh-paste-input](https://github.com/lhh010/dsh-paste-input) — File-input enhancements for the Web UI: Ctrl+V paste, drag-and-drop, and file picking, copied into the session workspace on send.
 - [Moeblack/deepseek-manners](https://github.com/Moeblack/deepseek-manners) — Injects a thank-you note after every message.
 - [Moeblack/dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) — Prompt Studio: edit user and built-in system-prompt sections with live preview.
-- [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — Imports Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode chat histories so conversations can continue in DSH.
+- [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — Imports full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) so conversations can continue in DSH, with reverse export/sync back to Claude Code.
 - [omdsh-dev/7d7d](https://github.com/omdsh-dev/7d7d) — 7k7k-style game portal: the model generates or uploads HTML5/Flash minigames playable in the Web UI (fixed-version, checksum-verified Ruffle for Flash).
 - [omdsh-dev/dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) — Auto-chess in the DSH Web UI: play against the AI or watch two AIs battle.
 - [omdsh-dev/dsh-daily-fortune](https://github.com/omdsh-dev/dsh-daily-fortune) — Daily fortune plugin with Guan Yin lots, Tarot spreads, and daily quotes.


### PR DESCRIPTION
## 改动内容

更新 `dsh-chat-import`（Nwflower）条目描述：旧描述仅列 7 源，实际支持 **13 种来源**（Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi），另有反向 `export_claude` / `sync_to_claude` 写回 Claude Code。

**改动前：** `Imports Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode chat histories so conversations can continue in DSH.`

**改动后：** `Imports full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) so conversations can continue in DSH, with reverse export/sync back to Claude Code.`

## 自检

- 仅改动我们的条目描述，未触碰其他内容