### PR TITLE
Add dsh-reverse-skill (85-skill reverse-engineering pack) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ _Bridges DSH into chat platforms and messaging channels._
 - [YLifeOnlyOnce/dsh-smarthome](https://github.com/YLifeOnlyOnce/dsh-smarthome) — Home Assistant control for DeepSeek Harness agents — approval-gated lights, switches, climate.
 
 ## Plugin Marketplaces & Ecosystem
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 
 _Plugin marketplaces, install managers, indexes, and ecosystem tooling._
 


### PR DESCRIPTION
Adds [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — a DeepSeek Harness Cordis plugin bundling 85 SKILL.md reverse-engineering / authorized-pentest / security-research skills.

Installable via `dsh plugin add github:dhicoc/dsh-reverse-skill`.