### PR TITLE
Add DeepSeek Harness Handbook to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [DeepSeek Harness overview (ai-bot.cn)](https://ai-bot.cn/deepseek-harness) — Third-party writeup.
 - [Finding the Best Harness for DeepSeek V4 Flash (Composio)](https://composio.dev/content/best-agent-harness-deepseek-v4-flash)
 - [flaqai/deepeseek-harness-guide](https://github.com/flaqai/deepeseek-harness-guide) — Guide for development with DeepSeek Harness; building a plugin for the DeepSeek Harness project.
+- [sandbaseai/deepseek-harness-handbook](https://github.com/sandbaseai/deepseek-harness-handbook) — Agent-first, multilingual handbook covering architecture, quickstarts, MCP, skills, subagents, sandboxing, and source-backed troubleshooting.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -694,6 +694,7 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) —— 官方源码仓库。  `⭐38238`
 - [DeepSeek Harness 概览（ai-bot.cn）](https://ai-bot.cn/deepseek-harness) —— 第三方解读。
 - [flaqai/deepeseek-harness-guide](https://github.com/flaqai/deepeseek-harness-guide) —— DeepSeek Harness 开发指南；为 DeepSeek Harness 项目构建插件。
+- [sandbaseai/deepseek-harness-handbook](https://github.com/sandbaseai/deepseek-harness-handbook) —— Agent-first 多语言手册，覆盖架构、快速入门、MCP、Skills、Subagents、沙箱和基于源码的故障排查。
 
 ## 贡献指南
 


### PR DESCRIPTION
## Summary

Add `sandbaseai/deepseek-harness-handbook` to the Resources section in both English and Chinese READMEs, as required by the contribution guide.

The description is factual and distinguishes the project as an agent-first, multilingual handbook covering architecture, quickstarts, MCP, skills, subagents, sandboxing, and source-backed troubleshooting.

## Validation

- project is public, working, and Apache-2.0 licensed
- repository carries the `dsh` topic
- no existing entry or open submission found
- English and Chinese resource entries kept in sync
- `git diff --check` passes
