### PR TITLE
docs: add dsh-genie (Plugin Marketplaces & Ecosystem)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ _Plugin marketplaces, install managers, indexes, and ecosystem tooling._
 - [dshworks/dshworks.github.io](https://github.com/dshworks/dshworks.github.io) — Landing page for dsh.works, the community workshop for DeepSeek Harness (dsh); single static page, zero JS.
 - [zebbkira/dsh-skills-mcp-manager](https://github.com/zebbkira/dsh-skills-mcp-manager) — Official-style plugin bundle adding a "Skills & MCP" card to the Web UI plugins settings group for managing skills and MCP servers in the browser.
 - [meifeisite/plugin-manager](https://github.com/meifeisite/plugin-manager) — Centralized plugin manager in DSH Web Settings → Plugins: enable/disable, uninstall with dependency checks, details, operation logs, and protection for core components.
+- [swaylq/dsh-genie](https://github.com/swaylq/dsh-genie) — Makes an agent's runtime plugins permanent: turns a `cordis_define` dynamic package into a real installed bundle that survives restart, with no pnpm, no network, and no build authorization.
 
 ## Visualization
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -294,6 +294,7 @@ _插件市场、安装管理器、索引与生态工具。_
 - [dshworks/dshworks.github.io](https://github.com/dshworks/dshworks.github.io) — dsh.works 落地页：DeepSeek Harness (dsh) 社区工坊，纯静态单页，零 JS。
 - [zebbkira/dsh-skills-mcp-manager](https://github.com/zebbkira/dsh-skills-mcp-manager) — 面向 DeepSeek Harness Web GUI 的正式插件包：在设置页的「Web UI 插件」分组中新增一张「技能与 MCP」卡片，用于在浏览器里管理技能（skills）与 MCP 服务器。
 - [meifeisite/plugin-manager](https://github.com/meifeisite/plugin-manager) —— 在 DeepSeek Harness（Web 版）设置 → 插件中提供集中管控界面：启停 / 卸载（含依赖检查）/ 详情 / 操作日志，核心组件受保护。
+- [swaylq/dsh-genie](https://github.com/swaylq/dsh-genie) —— 把 agent 现场造的插件变成永久插件：将 `cordis_define` 的动态包固化成能跨重启存活的正式组合包，不用 pnpm、不联网、不需要构建授权。
 
 ## 可视化
 


### PR DESCRIPTION
One entry under **Plugin Marketplaces & Ecosystem**, in both `README.md` and `README.zh-CN.md`, using each file's separator convention.

**[swaylq/dsh-genie](https://github.com/swaylq/dsh-genie)** — DSH ships `cordis_define` / `cordis_run`, so an agent can write a plugin and hot-load it into the running process. The upstream README for that toolset is explicit that a dynamic package "cannot be promoted automatically" and does not survive a restart, and points you at the regular development workflow to keep one. dsh-genie collapses that workflow into a tool call: `genie_keep` reads the dynamic package back out of the live runtime and writes it as a real installable bundle, `genie_wish` does the same for code written directly, and `genie_revoke` / `/wish` manage what has been granted.

Install writes the package into `$DSH_HOME/genie/`, links it where the launcher already resolves modules, and appends one name to `dsh.profile.bundles` — so no pnpm, no network, and no `allowBuilds` grant.

Checklist:
- [x] Repo carries the `dsh` topic (also `dsh-plugin`, `deepseek-harness`, `cordis`).
- [x] Both README files edited.
- [x] One PR, one logical change.
- [x] Real and working: verified end to end against `@deepseek-ai/dsh@0.1.0-rc.6` — install from GitHub, boot, grant, restart, the wish loads; revoke, restart, it is gone. 19 unit tests, no network.
- [x] Factual description, no hype.

MIT, plain JavaScript, no build step and no dependencies. The README carries an explicit trust-stance section, since a granted wish is ordinary code that runs at every boot: nothing executes in the session that writes it, generated modules are parse-checked with `node --check` rather than evaluated, and the restart is the user's checkpoint.