### PR TITLE
Add riffkit/skill under Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [Equinox7379/dsh-skill-search](https://github.com/Equinox7379/dsh-skill-search) — On-demand skill search for DSH: zero preloading, keyword-search a shared skill library.
 - [liuqh16/dsh-processes](https://github.com/liuqh16/dsh-processes) — Manage background processes from DeepSeek Harness: process tool, `/ps` commands, output inspection, exit/log-match notifications; a DSH port of pi-processes.
 - [dhicoc/dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) — Five Movements and Six Qi (Wuyun Liuqi) AI agent skill pack as a DeepSeek Harness (dsh) Cordis plugin: 31 SKILL.md skills, one-line `dsh plugin add` install.
+- [riffkit/skill](https://github.com/riffkit/skill) — Short-video generation skill: rebuild a winning TikTok's formula into your own product video, with optional digital character, product placement, and 9 output languages. Works with any agent that reads SKILL.md.
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -712,6 +712,7 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [Equinox7379/dsh-skill-search](https://github.com/Equinox7379/dsh-skill-search) —— DSH 按需技能检索：零预加载，关键词检索共享技能库。
 - [liuqh16/dsh-processes](https://github.com/liuqh16/dsh-processes) — 从 DeepSeek Harness 管理后台进程：process 工具、/ps 命令、输出查看、退出/日志匹配通知，pi-processes 的 DSH 移植版。
 - [dhicoc/dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) —— 五运六气（运气学）AI Agent 技能包的 DeepSeek Harness（dsh）Cordis 插件：31 个 SKILL.md 技能原样封装，一行 dsh plugin add 安装。
+- [riffkit/skill](https://github.com/riffkit/skill) —— 短视频生成技能：把一条已验证爆款的公式复刻成你自己的产品视频，可选数字人、产品植入与 9 种输出语言。任何能读 SKILL.md 的 agent 都可用。
 
 ## 资源
 


### PR DESCRIPTION
Adds [riffkit/skill](https://github.com/riffkit/skill) to the **Skills** section in both `README.md` and `README.zh-CN.md`.

**What it is:** a markdown-based skill (a single `SKILL.md`) for short-video generation — give it one source (a TikTok link, an uploaded video, or an analyzed template) and it rebuilds that video's formula into your own product video, with optional digital character, product placement, and 9 output languages.

**Honest scope note:** this is a `SKILL.md`, not a Cordis bundle plugin — there is no `package.json` / `dsh.bundle`, and it is not installed via `dsh plugin add`. It is loaded by DSH's filesystem skill provider from the shared skill root:

```bash
mkdir -p ~/.agents/skills/riffkit && curl -sSL https://riffkit.ai/SKILL.md -o ~/.agents/skills/riffkit/SKILL.md
```

Verified against `@deepseek-ai/dsh-skill-filesystem@0.1.0-rc.6` itself (the version `@deepseek-ai/dsh@0.1.0-rc.6` depends on — note npm’s `latest` dist-tag for that package still points at the older `0.0.1-rc.3`): discovered from `~/.agents/skills/riffkit/SKILL.md`, frontmatter parsed (`name: riffkit`), `modelInvocable` and `userInvocable` both true, and the full body loads. Placing it under **Skills** rather than Plugins for exactly this reason — happy to move or drop it if you would rather that section stay bundle-only.

**Checklist**
- [x] Repo tagged with the `dsh` topic
- [x] Both `README.md` and `README.zh-CN.md` edited, kept in sync (` — ` / ` —— ` separators)
- [x] Format `- [Name](https://link) — Concise one-line description.`
- [x] Real, working, publicly accessible; description factual and hype-free
- [x] One PR, one logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)