### PR TITLE
docs: add dsh-digipet (UI / Clients)

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [dbydd/dsh-onlyne](https://github.com/dbydd/dsh-onlyne) — Gives DSH agents a real IM inbox/outbox (Telegram, Feishu/Lark, QQ Bot, WeChat) through the Onlyne workspace-local channel daemon.
 - [LaplaceYoung/dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) — QQ2006 skin: registers a `qq2006` theme with a full global skin table and assets.
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) — Desktop-pet plugin for the Web GUI (QQ-pet style): a draggable floating companion you can feed and play with.  `⭐27`
+- [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) — Digimon-style raising game: hatch an egg that feeds on real work (turns, tools, errors) and evolves along four lines shaped by how you work; command-only, zero tokens, no model-facing surface.
 - [ccch1mneyyy/dsh-working-activity](https://github.com/ccch1mneyyy/dsh-working-activity) — Live model working-status line for the TUI prompt bar and Web UI: playful thinking copy, running tools, turn summaries, and self-narration.
 - [orriduck/dsh-tui](https://github.com/orriduck/dsh-tui) — A small, session-aware terminal UI for DeepSeek Harness.
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) — Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -511,6 +511,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [dbydd/dsh-onlyne](https://github.com/dbydd/dsh-onlyne) —— 通过 Onlyne（工作区本地 IM 通道守护进程）给 DSH agent 一个真正的 IM 收发件箱：Telegram、飞书、QQ 机器人、微信。
 - [LaplaceYoung/dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) —— QQ2006 皮肤插件：注册 `qq2006` 主题、全局皮肤表与完整素材。
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) —— Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽 / 投喂 / 玩耍的积累型伙伴。  `⭐27`
+- [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) —— 数码宝贝式养成：孵一颗吃真实工作长大的蛋（回合、工具、报错都是营养），按工作方式走四条进化路线；纯命令交互，零 token，无模型可见面。
 - [ccch1mneyyy/dsh-working-activity](https://github.com/ccch1mneyyy/dsh-working-activity) —— 实时模型工作状态行：俏皮思考文案、运行中的工具、回合总结、自我叙述，用于 TUI 提示栏与 Web UI。
 - [orriduck/dsh-tui](https://github.com/orriduck/dsh-tui) —— 小巧的、会话感知的 DeepSeek Harness 终端 UI。
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) —— Rust/ratatui 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。


### PR DESCRIPTION
Adds **dsh-digipet** to UI / Clients in both `README.md` and `README.zh-CN.md`, right after whale-girl (its closest neighbor).

**What**: a Digimon-style raising game for DSH. `/pet hatch` lays an egg; it feeds on the agent's real work (completed turns, tool calls, user messages, errors) and evolves through the full classic stage chain (Egg → Baby Ⅰ → Baby Ⅱ → Child → Adult → Perfect → Ultimate) across a 22-slot dex, along four lineages (dragon / sage / angel / virus) — each evolution re-reads which stat dominated that stage, so the creature mirrors how its human actually works. A hidden care-mistake line honors the genre's oldest tradition: evolve on a stuffed belly and you get the slug (redeemable, or double down).

**Why it adds signal next to the existing pets**: the current pets are state mirrors / skins; this is the first hatch-and-evolve progression pet. It is also the zero-cost outlier: no client half, no model-facing tool, no context injection — four notification-mode event taps plus one slash command, so it works with zero tokens per request.

**Category note**: placed next to whale-girl for kinship; it has no browser half (command-only), so feel free to recategorize if you prefer.

**Facts**: `#dsh` topic tagged; verified on dsh `0.1.0-rc.6` (install → boot → command dispatch → real-event feeding → hatch ceremony → cross-restart save migration); 42 unit/integration tests; MIT; pure JS, zero deps, installable via `dsh plugin --profile web add github:swaylq/dsh-digipet`. Old 0.1.x saves migrate automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
