### PR TITLE
Add AbnerAI/dsh-monitor to Agents category

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ _Reusable sub-agents / specialized agent packs runnable inside DSH._
 - [yhny1001/dsh-rp-distribution](https://github.com/yhny1001/dsh-rp-distribution) — Plugin-first open-source role-playing distribution for DeepSeek Harness.
 - [superboy911/dsh-model-router](https://github.com/superboy911/dsh-model-router) — DSH model-routing plugin for keyword routing and isolated image generation.
 - [omdsh-dev/dsh-office](https://github.com/omdsh-dev/dsh-office) — Office document tools for DeepSeek Harness: generate, read, and edit spreadsheets (.xlsx), PDFs, and presentations (.pptx).
+- [AbnerAI/dsh-monitor](https://github.com/AbnerAI/dsh-monitor) — Persistent background watchers (file inbox / command output) that wake the agent on new messages; the harness analog of Claude Code's Monitor tool.
 
 ## Loops (Auto-Research, Self-Improve, etc.)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -460,6 +460,7 @@ _可在 DSH 内运行的可复用子 agent / 专用 agent 包。_
 - [yhny1001/dsh-rp-distribution](https://github.com/yhny1001/dsh-rp-distribution) — 面向 DeepSeek Harness 的插件优先开源角色扮演分发包。
 - [superboy911/dsh-model-router](https://github.com/superboy911/dsh-model-router) — DSH 关键词路由与隔离生图插件。
 - [omdsh-dev/dsh-office](https://github.com/omdsh-dev/dsh-office) — 办公三件套！DeepSeek Harness (dsh) 的 Office 文档工具：生成、读取和编辑表格(.xlsx)、PDF 及演示文稿(.pptx)。
+- [AbnerAI/dsh-monitor](https://github.com/AbnerAI/dsh-monitor) — 常驻后台监视器（文件收件箱/命令输出）：新消息一到即唤醒 Agent，是 Claude Code Monitor 工具的 Harness 对应实现。
 
 ## 循环（自动研究 / 自我改进等）
 


### PR DESCRIPTION
### What

Add [**AbnerAI/dsh-monitor**](https://github.com/AbnerAI/dsh-monitor) to the **Agents** category in both `README.md` and `README.zh-CN.md`.

### About the plugin

`dsh-monitor` arms persistent background watchers (append-only NDJSON file inbox or shell command output delta) that wake the owning agent when new content arrives — the harness analog of Claude Code's `Monitor` tool.

### Compliance

- ✅ Declares `dsh.bundle` manifest (installable via `dsh plugin add`)
- ✅ Real working code, MIT license
- ✅ `dsh-plugin` topic added