### PR TITLE
Add cn-intel-board: China supply-chain intel MCP server (#dsh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,8 @@ _Model Context Protocol servers that contribute tools / prompts / resources to D
 
 - [wly8691-jpg/knowlp-rag](https://github.com/wly8691-jpg/knowlp-rag) — Dual knowledge-graph RAG for Markdown notes — MCP + native Cordis plugin for DeepSeek Harness and Claude Code.
 
+- [lory69060/cn-intel-board](https://github.com/lory69060/cn-intel-board) — China hard-tech supply-chain intel MCP server (pure stdlib): 33 verifiable signals with track record, 2026 H1 earnings tracker, ask_edge Q&A. Data-asset play: agents can read real China supply-chain data, not headlines.
+
 ## Orchestrators & Aggregators
 
 _Multi-step / multi-agent schedulers and output aggregators._


### PR DESCRIPTION
## What

Add [lory69060/cn-intel-board](https://github.com/lory69060/cn-intel-board) to the **MCP Servers** section.

## Why

A machine-readable **China supply-chain intel** data asset for agents:
- `read_signal_board` — 33 verifiable signals (storage/semiconductors, rare earth, EV, AI infra), each with `predicted_on`/`verify_by`/`verify_event`/`result` track-record fields
- `get_track_record` — hit-rate analytics
- `ask_edge` — edge/contrarian Q&A
- `read_earnings_tracker` — 2026 H1 earnings tracker (akshare-verified, updated daily to 8/31)

Pure stdlib, zero deps. Repo carries the `#dsh` topic.