### PR TITLE
Add open-mcp-apps (MCP Servers) and dsh-plugin-open-app (UI / Clients)

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ _Model Context Protocol servers that contribute tools / prompts / resources to D
 
 - [DDDMUC/dsh-free-search](https://github.com/DDDMUC/dsh-free-search) — Free web search provider for DeepSeek Harness — DuckDuckGo backend, no API key needed.
 - [lory69060/cn-intel-board](https://github.com/lory69060/cn-intel-board) — China hard-tech supply-chain intel MCP server (pure stdlib): 33 verifiable signals with track record, 2026 H1 earnings tracker, ask_edge Q&A. Data-asset play: agents can read real China supply-chain data, not headlines.
+- [2nd1st/open-mcp-apps](https://github.com/2nd1st/open-mcp-apps) — MCP Apps engine: the model builds, persists, and reuses interactive UI apps — boards, trackers, dashboards — backed by data collections that outlive the conversation. Usable from DSH through the MCP client; ships a 22-app App Store.
 
 ## Orchestrators & Aggregators
 
@@ -810,6 +811,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [Xizhi1024/dsh-vs-sidebar](https://github.com/Xizhi1024/dsh-vs-sidebar) — VS Code sidebar extension for DeepSeek Harness.
 - [xxccdl/deepseek-harness-desktop](https://github.com/xxccdl/deepseek-harness-desktop) — DeepSeek Harness Desktop — Electron shell wrapping dsh web with desktop-only plugins: memory viewer, computer use, desktop settings, scheduler, quick chat, and usage bar.
 - [zhxqc/dsh-oh-my-theme](https://github.com/zhxqc/dsh-oh-my-theme) — Web plugin for DeepSeek Harness (dsh) with themes, global typography, @file mentions, project file tree, and Markdown preview.
+- [2nd1st/dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) — Brings open-mcp-apps into DSH: each MCP app becomes a sidebar container with its own workspace, session and App mode, plus an agent status strip under the app and inline app rendering in ordinary chats.
 
 ## Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -525,6 +525,7 @@ _向 DSH 贡献工具 / prompt / 资源的 Model Context Protocol server。_
 - [wly8691-jpg/knowlp-rag](https://github.com/wly8691-jpg/knowlp-rag) —— 面向 Markdown 笔记的双知识图谱 RAG：DeepSeek Harness 与 Claude Code 的 MCP + 原生 Cordis 插件。
 
 - [DDDMUC/dsh-free-search](https://github.com/DDDMUC/dsh-free-search) —— DeepSeek Harness 免费网页搜索 provider：DuckDuckGo 后端，无需 API key。
+- [2nd1st/open-mcp-apps](https://github.com/2nd1st/open-mcp-apps) —— MCP Apps 引擎：模型自己建、保存并复用交互式 UI app（看板、追踪器、仪表盘），背后是跨会话存续的数据集合。可通过 MCP 客户端在 DSH 中使用，自带 22 个 app 的 App Store。
 
 ## 编排器与聚合器
 
@@ -799,6 +800,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [Xizhi1024/dsh-vs-sidebar](https://github.com/Xizhi1024/dsh-vs-sidebar) —— DeepSeek Harness 的 VS Code 侧边栏扩展。
 - [xxccdl/deepseek-harness-desktop](https://github.com/xxccdl/deepseek-harness-desktop) —— DeepSeek Harness 桌面版：Electron 壳层封装 dsh web，集成记忆查看、电脑控制、桌面设置、定时任务、快捷对话、预算血条等桌面插件。
 - [zhxqc/dsh-oh-my-theme](https://github.com/zhxqc/dsh-oh-my-theme) —— DeepSeek Harness (dsh) web 插件：主题、全局排版、@file 提及、项目文件树与 Markdown 预览。
+- [2nd1st/dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) —— 把 open-mcp-apps 带进 DeepSeek Harness：每个 MCP app 都是侧边栏里自己的容器（workspace + 会话 + App mode），带 agent 状态条、聊天内行内渲染与 App Store。
 
 ## Skill
 


### PR DESCRIPTION
Adds two entries from the same project, each in its own category. Both `README.md` and `README.zh-CN.md` are updated and stay in sync (zh uses ` —— `).

**MCP Servers — [2nd1st/open-mcp-apps](https://github.com/2nd1st/open-mcp-apps)**
An MCP Apps engine: the model builds an interactive UI app once — a board, a tracker, a dashboard — and it persists, backed by data collections that outlive the conversation. DSH reaches it through the MCP client (`streamable-http`), so it contributes tools to DSH like any other MCP server. Ships a 22-app App Store. AGPL-3.0 engine, MIT apps.
Install: `curl -fsSL https://raw.githubusercontent.com/2nd1st/open-mcp-apps/main/install.sh | sh`

**UI / Clients — [2nd1st/dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app)**
The DSH face of that engine: each MCP app becomes a sidebar container with its own workspace, session and App mode system prompt; an agent status strip sits under the app UI; and in an ordinary chat an `open_app` tool call renders as the running app inline. Runs out-of-tree — no dsh source changes. MIT, npm `0.1.0`.
Install: `dsh plugin add dsh-plugin-open-app`, then a patch row in the profile's `cordis.patch.yml`.

Both repos carry the `dsh` topic. Neither was previously listed (grepped both READMEs). Both are at `0.1.0` / developer-preview stage against dsh `0.1.0-rc`; happy to move either entry if you'd rather categorize differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
