### PR TITLE
Add SendPage under MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ _Model Context Protocol servers that contribute tools / prompts / resources to D
 - [DDDMUC/dsh-free-search](https://github.com/DDDMUC/dsh-free-search) — Free web search provider for DeepSeek Harness — DuckDuckGo backend, no API key needed.
 - [lory69060/cn-intel-board](https://github.com/lory69060/cn-intel-board) — China hard-tech supply-chain intel MCP server (pure stdlib): 33 verifiable signals with track record, 2026 H1 earnings tracker, ask_edge Q&A. Data-asset play: agents can read real China supply-chain data, not headlines.
 - [2nd1st/open-mcp-apps](https://github.com/2nd1st/open-mcp-apps) — MCP Apps engine: the model builds, persists, and reuses interactive UI apps — boards, trackers, dashboards — backed by data collections that outlive the conversation. Usable from DSH through the MCP client; ships a 22-app App Store.
+- [jcaiagent7143-ui/sendpage-mcp](https://github.com/jcaiagent7143-ui/sendpage-mcp) — MCP server that turns an HTML document into a shareable link that opens in one tap and previews as a card in chat apps; publish, update, and export to PNG/PDF/Word. Free key, no signup.
 
 ## Orchestrators & Aggregators
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -565,6 +565,7 @@ _向 DSH 贡献工具 / prompt / 资源的 Model Context Protocol server。_
 
 - [DDDMUC/dsh-free-search](https://github.com/DDDMUC/dsh-free-search) —— DeepSeek Harness 免费网页搜索 provider：DuckDuckGo 后端，无需 API key。
 - [2nd1st/open-mcp-apps](https://github.com/2nd1st/open-mcp-apps) —— MCP Apps 引擎：模型自己建、保存并复用交互式 UI app（看板、追踪器、仪表盘），背后是跨会话存续的数据集合。可通过 MCP 客户端在 DSH 中使用，自带 22 个 app 的 App Store。
+- [jcaiagent7143-ui/sendpage-mcp](https://github.com/jcaiagent7143-ui/sendpage-mcp) —— 把 HTML 文档变成一键打开、在聊天里显示预览卡的分享链接的 MCP 服务;支持发布、更新,以及导出 PNG/PDF/Word。免费 key,无需注册。
 
 ## 编排器与聚合器
 


### PR DESCRIPTION
Adds **SendPage** to the MCP Servers section (both README.md and README.zh-CN.md, kept in sync).

- Repo: https://github.com/jcaiagent7143-ui/sendpage-mcp (tagged `#dsh` / `dsh-plugin`)
- What it is: a remote (streamable-HTTP) MCP server that turns an HTML document into a shareable link — opens in one tap, previews as a card in chat apps — with publish / update / export (PNG, PDF, Word) tools. Free key, no signup.
- Usable from DSH by adding the endpoint `https://sendpageapp.com/mcp`.

Description is factual and hype-free per CONTRIBUTING; entry appended to the section.