### PR TITLE
Add dsh-wildmon (Pokemon-style catch-em-all, zero tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [LaplaceYoung/dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) — QQ2006 skin: registers a `qq2006` theme with a full global skin table and assets.
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) — Desktop-pet plugin for the Web GUI (QQ-pet style): a draggable floating companion you can feed and play with.  `⭐27`
 - [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) — Digimon-style raising game: hatch an egg that feeds on real work (turns, tools, errors) and evolves along four lines shaped by how you work; command-only, zero tokens, no model-facing surface.
+- [swaylq/dsh-wildmon](https://github.com/swaylq/dsh-wildmon) — Pokemon-style catch-em-all safari: real work rustles the grass — turns, tool calls and errors spawn wild encounters; throw balls, fill a 28-slot dex, build a team of six. Command-only, zero tokens, no model-facing surface.
 - [ccch1mneyyy/dsh-working-activity](https://github.com/ccch1mneyyy/dsh-working-activity) — Live model working-status line for the TUI prompt bar and Web UI: playful thinking copy, running tools, turn summaries, and self-narration.
 - [orriduck/dsh-tui](https://github.com/orriduck/dsh-tui) — A small, session-aware terminal UI for DeepSeek Harness.
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) — Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -627,6 +627,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [LaplaceYoung/dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) —— QQ2006 皮肤插件：注册 `qq2006` 主题、全局皮肤表与完整素材。
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) —— Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽 / 投喂 / 玩耍的积累型伙伴。  `⭐27`
 - [swaylq/dsh-digipet](https://github.com/swaylq/dsh-digipet) —— 数码宝贝式养成：孵一颗吃真实工作长大的蛋（回合、工具、报错都是营养），按工作方式走四条进化路线；纯命令交互，零 token，无模型可见面。
+- [swaylq/dsh-wildmon](https://github.com/swaylq/dsh-wildmon) —— 宝可梦式捕捉收集：真实工作就是草丛（回合、工具调用、报错刷出野外遭遇），投球捕捉、集 28 格图鉴、组 6 只队伍；纯命令交互，零 token，无模型可见面。
 - [ccch1mneyyy/dsh-working-activity](https://github.com/ccch1mneyyy/dsh-working-activity) —— 实时模型工作状态行：俏皮思考文案、运行中的工具、回合总结、自我叙述，用于 TUI 提示栏与 Web UI。
 - [orriduck/dsh-tui](https://github.com/orriduck/dsh-tui) —— 小巧的、会话感知的 DeepSeek Harness 终端 UI。
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) —— Rust/ratatui 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。


### PR DESCRIPTION
Adds **dsh-wildmon** to *UI / Clients*, right after its sibling dsh-digipet.

**What it is**: the collect-em-all loop (encounter → catch → dex collection → team of six) mounted on real harness work — turns, tool calls and errors roll wild encounters (errors loudest; 00:00–05:59 wakes a night pool), balls get thrown, a 28-slot dex fills up. Zero tokens, zero tools, no model-facing surface; every listener is try/catch-wrapped and it only writes its own save file.

**Why it's not a duplicate**: the pet lane has state mirrors (whale-girl, Clippy, …) and one raising game (dsh-digipet). Collecting was empty — pokemon / pokedex / catching / gacha give zero hits in the `dsh-plugin` topic (2,800+ repos) and the curated lists as of 2026-08. wildmon and digipet are complementary (breadth vs depth) and install side by side.

**Verified** on dsh `0.1.0-rc.6` (macOS, web profile): `dsh plugin --profile web add github:swaylq/dsh-wildmon` installs (pure JS, zero deps, no `prepare` script), boots clean, and the full encounter → throw → catch → dex flow was driven in a real browser, with the save file reconciling line by line against observed events. 61 unit/integration tests.

**IP note**: all 28 species names, ASCII art and copy are original; no franchise names or assets (see the README's "Homage and boundaries" section).

- [x] Repo tagged with `dsh` / `dsh-plugin` / `deepseek-harness` / `cordis` / `ai-agents` topics
- [x] Both `README.md` and `README.zh-CN.md` updated in this PR
- [x] MIT licensed
