### PR TITLE
Add dsh-memory-plugin-traex to Session & Memory Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [GIT121995/dsh-memory-gate](https://github.com/GIT121995/dsh-memory-gate) — CBDC-gated memory for DeepSeek Harness: decides how retrieved memory is used (use/verify/ignore, feedback learning, audit) rather than just storing it.
 - [EveGoodEvening/dsh-llmwiki](https://github.com/EveGoodEvening/dsh-llmwiki) — Local-first, evidence-backed Markdown wiki plugin (Karpathy llm-wiki concept): immutable source records by content hash, synthesized pages citing source IDs, and a deterministic section index for lexical search.
 - [jiayuxuan123/dsh-session-history-fix](https://github.com/jiayuxuan123/dsh-session-history-fix) — Session history fix plugin for DeepSeek Harness.
-- [volcengine/OpenViking (dsh-memory-plugin-traex)](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin-traex) — Self-evolving context/memory plugin for DeepSeek Harness backed by OpenViking's context database; unifies session memory, knowledge RAG, and skills behind one storage/retrieval layer exposed as DSH memory tools.
+- [volcengine/OpenViking (dsh-memory-plugin)](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin) — Self-evolving context/memory plugin for DeepSeek Harness backed by OpenViking's context database; unifies session memory, knowledge RAG, and skills behind one storage/retrieval layer exposed as DSH memory tools.
 
 - [huahai0202/dsh-better-archive](https://github.com/huahai0202/dsh-better-archive) — DSH web-GUI plugin: archived-session panel with unarchive and delete.
 - [lmst2/dsh-asc](https://github.com/lmst2/dsh-asc) — Agentic Surface Compaction (ASC) — context-management / compaction plugin for DeepSeek Harness.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [GIT121995/dsh-memory-gate](https://github.com/GIT121995/dsh-memory-gate) — CBDC-gated memory for DeepSeek Harness: decides how retrieved memory is used (use/verify/ignore, feedback learning, audit) rather than just storing it.
 - [EveGoodEvening/dsh-llmwiki](https://github.com/EveGoodEvening/dsh-llmwiki) — Local-first, evidence-backed Markdown wiki plugin (Karpathy llm-wiki concept): immutable source records by content hash, synthesized pages citing source IDs, and a deterministic section index for lexical search.
 - [jiayuxuan123/dsh-session-history-fix](https://github.com/jiayuxuan123/dsh-session-history-fix) — Session history fix plugin for DeepSeek Harness.
+- [volcengine/OpenViking (dsh-memory-plugin-traex)](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin-traex) — Self-evolving context/memory plugin for DeepSeek Harness backed by OpenViking's context database; unifies session memory, knowledge RAG, and skills behind one storage/retrieval layer exposed as DSH memory tools.
 
 - [huahai0202/dsh-better-archive](https://github.com/huahai0202/dsh-better-archive) — DSH web-GUI plugin: archived-session panel with unarchive and delete.
 - [lmst2/dsh-asc](https://github.com/lmst2/dsh-asc) — Agentic Surface Compaction (ASC) — context-management / compaction plugin for DeepSeek Harness.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -249,7 +249,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [GIT121995/dsh-memory-gate](https://github.com/GIT121995/dsh-memory-gate) — DeepSeek Harness 的 CBDC 门控记忆插件：决定检索到的记忆如何被使用（使用/校验/忽略 + 反馈学习 + 审计），而不只是存储。
 - [EveGoodEvening/dsh-llmwiki](https://github.com/EveGoodEvening/dsh-llmwiki) —— 本地优先、证据支持的 Markdown wiki 插件（Karpathy llm-wiki 概念）：源记录按内容哈希不可变保存，合成页面引用源 ID，确定性章节索引支持词法检索。
 - [jiayuxuan123/dsh-session-history-fix](https://github.com/jiayuxuan123/dsh-session-history-fix) —— DeepSeek Harness 会话历史修复插件。
-- [volcengine/OpenViking (dsh-memory-plugin-traex)](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin-traex) —— 基于 OpenViking 上下文数据库的 DeepSeek Harness 自演化上下文/记忆插件：将会话记忆、知识 RAG 与技能统一在一个存储/检索层，以 DSH 记忆工具的形式暴露。
+- [volcengine/OpenViking (dsh-memory-plugin)](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin) —— 基于 OpenViking 上下文数据库的 DeepSeek Harness 自演化上下文/记忆插件：将会话记忆、知识 RAG 与技能统一在一个存储/检索层，以 DSH 记忆工具的形式暴露。
 
 - [huahai0202/dsh-better-archive](https://github.com/huahai0202/dsh-better-archive) —— DeepSeek Harness Web 插件：归档会话面板，支持取消归档与删除。
 - [lmst2/dsh-asc](https://github.com/lmst2/dsh-asc) —— dsh-asc（Agentic Surface Compaction）：DeepSeek Harness 上下文管理与压缩插件。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -249,6 +249,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [GIT121995/dsh-memory-gate](https://github.com/GIT121995/dsh-memory-gate) — DeepSeek Harness 的 CBDC 门控记忆插件：决定检索到的记忆如何被使用（使用/校验/忽略 + 反馈学习 + 审计），而不只是存储。
 - [EveGoodEvening/dsh-llmwiki](https://github.com/EveGoodEvening/dsh-llmwiki) —— 本地优先、证据支持的 Markdown wiki 插件（Karpathy llm-wiki 概念）：源记录按内容哈希不可变保存，合成页面引用源 ID，确定性章节索引支持词法检索。
 - [jiayuxuan123/dsh-session-history-fix](https://github.com/jiayuxuan123/dsh-session-history-fix) —— DeepSeek Harness 会话历史修复插件。
+- [volcengine/OpenViking (dsh-memory-plugin-traex)](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin-traex) —— 基于 OpenViking 上下文数据库的 DeepSeek Harness 自演化上下文/记忆插件：将会话记忆、知识 RAG 与技能统一在一个存储/检索层，以 DSH 记忆工具的形式暴露。
 
 - [huahai0202/dsh-better-archive](https://github.com/huahai0202/dsh-better-archive) —— DeepSeek Harness Web 插件：归档会话面板，支持取消归档与删除。
 - [lmst2/dsh-asc](https://github.com/lmst2/dsh-asc) —— dsh-asc（Agentic Surface Compaction）：DeepSeek Harness 上下文管理与压缩插件。


### PR DESCRIPTION
Adds `dsh-memory-plugin-traex` to the Session & Memory Management section in both README.md and README.zh-CN.md.

This is a DeepSeek Harness memory plugin backed by [OpenViking](https://github.com/volcengine/OpenViking)'s self-evolving context database — it unifies session memory, knowledge RAG, and skills behind one storage/retrieval layer, exposed to DSH as memory tools. It lives at `examples/dsh-memory-plugin-traex` in the OpenViking monorepo (merged via [volcengine/OpenViking#3993](https://github.com/volcengine/OpenViking/pull/3993)), so the link points at that subdirectory rather than a standalone repo — noting this since the contributing guide's `#dsh` topic-tagging step doesn't apply to a subdirectory.
