### PR TITLE
docs: add TMCRA Agent Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 
 _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 
+- [reshuibuduo/TMCRA-Agent-Memory](https://github.com/reshuibuduo/TMCRA-Agent-Memory) — Technical-preview owner-local graph memory for DSH and Codex: recalls owner-global and current-project evidence before each turn, keeps USER and ASSISTANT records separate, and preserves project, session, actor, and source provenance.
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
 - [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) — Bounded cross-session memory backed by SQLite.
 - [Spirtxiaoqi7/mindspace-dsh-session-memory](https://github.com/Spirtxiaoqi7/mindspace-dsh-session-memory) — Session-isolated personalized memory.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,6 +250,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 
 _跨会话记忆、checkpoint、会话置顶与导航插件。_
 
+- [reshuibuduo/TMCRA-Agent-Memory](https://github.com/reshuibuduo/TMCRA-Agent-Memory) —— 面向 DSH 与 Codex 的技术预览版本机图记忆：每轮前召回用户全局与当前项目证据，分别保存 USER 与 ASSISTANT 记录，并保留项目、会话、角色和来源信息。
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) —— 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。
 - [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) —— 基于 SQLite 的有界跨会话记忆。
 - [Spirtxiaoqi7/mindspace-dsh-session-memory](https://github.com/Spirtxiaoqi7/mindspace-dsh-session-memory) —— 会话隔离的个性化记忆。


### PR DESCRIPTION
## What are you adding?

- **Name:** TMCRA-Agent-Memory
- **Link:** https://github.com/reshuibuduo/TMCRA-Agent-Memory
- **Category:** Session & Memory Management
- **One-line description:** Technical-preview owner-local graph memory for DSH and Codex with scoped recall, role-separated writeback, and actor/source provenance.

## Checklist

- [x] The repo carries the `dsh-plugin` GitHub topic
- [x] I edited both `README.md` and `README.zh-CN.md`
- [x] The entry follows the requested one-line format
- [x] The description is factual and hype-free
- [x] The project is real, working, and publicly accessible

The DSH integration is contained in `integrations/deepseek-harness-local` and declares a `dsh.bundle` patch. Its technical-preview status is explicit in both catalog descriptions.