### PR TITLE
docs: add dsh-capability-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ _Plugin marketplaces, install managers, indexes, and ecosystem tooling._
 
 - [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) — DSH plugin mall: search GitHub dsh-plugin-topic plugins and install them into local dsh with one click (agent tool + plugin-market tab in settings).
 - [2160039878-cyber/dsh-plugin-market](https://github.com/2160039878-cyber/dsh-plugin-market) — A loud GitHub plugin radar for DeepSeek Harness.
+- [777-Zen/dsh-capability-index](https://github.com/777-Zen/dsh-capability-index) — Pre-flight plugin-library check: injects Top-K hints of suitable plugins with use_when/not_for capability declarations on task-type requests.
 - [apbigking-cell/dsh-plugin-square](https://github.com/apbigking-cell/dsh-plugin-square) — DSH plugin square + governance layer: real-time sync of GitHub dsh-plugin repos with search, translation, transactional install, and enable/disable/uninstall; governs plugins by universal/session/dual tiers with per-session on-demand activation, auto-release, and bloat audit.
 - [Casually/deepseek-harness-plugs-manage](https://github.com/Casually/deepseek-harness-plugs-manage) — Plugin management tool for DeepSeek Harness: search and install from the official plugin library.
 - [jianxx/dsh-cc-plugins](https://github.com/jianxx/dsh-cc-plugins) — DSH plugin collection (no description provided upstream).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,7 @@ _插件市场、安装管理器、索引与生态工具。_
 
 - [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) —— DSH 插件市场：搜索 GitHub dsh-plugin 话题插件，一键安装到本地 dsh（agent 工具 + 设置页插件市场 tab）。
 - [2160039878-cyber/dsh-plugin-market](https://github.com/2160039878-cyber/dsh-plugin-market) —— DeepSeek Harness 的 GitHub 插件雷达。
+- [777-Zen/dsh-capability-index](https://github.com/777-Zen/dsh-capability-index) —— 插件库起飞前检查单：任务型请求时注入 Top-K 适用插件提示（带 use_when/not_for 能力声明），让插件利用率可预期、不靠运气和直觉。
 - [apbigking-cell/dsh-plugin-square](https://github.com/apbigking-cell/dsh-plugin-square) —— DeepSeek Harness 插件广场 + 统筹层：实时同步 GitHub dsh-plugin，支持搜索、翻译、事务安装与启停卸载；按 universal/session/dual 分级治理插件，支持单会话按需激活、自动释放与臃肿审计。
 - [Casually/deepseek-harness-plugs-manage](https://github.com/Casually/deepseek-harness-plugs-manage) —— DeepSeek Harness 插件管理工具，方便搜索安装官方插件库。
 - [jianxx/dsh-cc-plugins](https://github.com/jianxx/dsh-cc-plugins) —— DSH 插件集合（上游无描述）。


### PR DESCRIPTION
<!-- Thanks for contributing to Awesome DeepSeek Harness! -->

  ## What are you adding?

  - **Name:** dsh-capability-index
  - **Link:** https://github.com/777-Zen/dsh-capability-index
  - **Category:** Plugin Marketplaces & Ecosystem
  - **One-line description:** Pre-flight plugin-library check: injects Top-K hints of suitable plugins with
  use_when/not_for capability declarations on task-type requests.

  ## Checklist

  - [x] The repo carries the `#dsh` GitHub topic
  - [x] I edited **both** `README.md` and `README.zh-CN.md`
  - [x] Entry follows the format: `- [Name](url) — description.`
  - [x] Description is factual and hype-free
  - [x] The project is real, working, and publicly accessible

  ## Notes

  - Meta-plugin: gives DSH agents a pre-flight plugin-library check. On task-type requests it injects a Top-K hint of
  suitable plugins — with the authors' `use_when`/`not_for` capability declarations — into the runtime-context snapshot.
  - Read-only, advisory, zero-invasive. Repo includes a B/C controlled experiment: call rate on non-obvious plugin tools
  went 0% → 100%, zero false triggers (direction-only, small sample); 32 unit tests + offline simulator reproducible.
  - Repo: https://github.com/777-Zen/dsh-capability-index · MIT · tagged `dsh-plugin` and `dsh`.