### PR TITLE
Add xulelenlp/dsh-web-artifact-designer (design-artifact skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1268,6 +1268,7 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [MichengAI/dsh-skills-manager](https://github.com/MichengAI/dsh-skills-manager) — Skills manager plugin for DeepSeek Harness: manage Skills from the UI.
 - [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) — 88 installable open-source Agent Skills for research, social intelligence, marketing, and business workflows — compatible with Codex, Claude Code, Cursor, Gemini CLI, and DeepSeek Harness.
 - [xu-jin-cs/dsh-skills](https://github.com/xu-jin-cs/dsh-skills) — Reusable skills for the DeepSeek Harness ecosystem: parallel-dispatch orchestration rules + archmap architecture-mapping agent (zero-LLM deterministic diff impact analysis, saves tokens).
+- [xulelenlp/dsh-web-artifact-designer](https://github.com/xulelenlp/dsh-web-artifact-designer) — Design-artifact skill adapted from Anthropic canvas-design / web-artifacts-builder: turns a design brief into a polished, self-contained HTML/SVG artifact (posters, infographics, landing pages, charts, component mockups) with a hard pre-delivery quality checklist and an anti-"AI-look" pattern list.
 
 
 - [Solismuchengxue/dsh_plugin_swift_cycle](https://github.com/Solismuchengxue/dsh_plugin_swift_cycle) — Swift Cycle governance-skill adapter for DeepSeek Harness; user-invoked, version-pinned, and offline-verifiable.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1248,6 +1248,7 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [MichengAI/dsh-skills-manager](https://github.com/MichengAI/dsh-skills-manager) —— 基于 DeepSeek Harness 的 Skills 管理插件。
 - [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) —— 88 个可安装的开源 Agent Skills：研究、社交智能、营销与商务工作流，兼容 Codex / Claude Code / Cursor / Gemini CLI / DeepSeek Harness。
 - [xu-jin-cs/dsh-skills](https://github.com/xu-jin-cs/dsh-skills) —— DeepSeek Harness 生态技能包：parallel-dispatch 并行调度规则 + archmap 架构测绘 Agent（零 LLM 确定性 diff 影响面，节约 tokens）。
+- [xulelenlp/dsh-web-artifact-designer](https://github.com/xulelenlp/dsh-web-artifact-designer) —— 面向 DSH 的设计稿生成 skill（改编自 Anthropic canvas-design / web-artifacts-builder）：把设计需求做成可直接打开的自包含 HTML/SVG 设计稿（海报、信息图、落地页、图表、组件稿），内置交付前硬性质量清单与「去 AI 味」反模式清单。
 
 
 - [Solismuchengxue/dsh_plugin_swift_cycle](https://github.com/Solismuchengxue/dsh_plugin_swift_cycle) —— DeepSeek Harness 的 Swift Cycle 治理技能适配器；用户按需调用、版本固定、可离线校验。


### PR DESCRIPTION
<!-- Thanks for contributing to Awesome DeepSeek Harness! -->

## What are you adding?

- **Name:** dsh-web-artifact-designer
- **Link:** https://github.com/xulelenlp/dsh-web-artifact-designer
- **Category:** Skills
- **One-line description:** Design-artifact skill adapted from Anthropic canvas-design / web-artifacts-builder: turns a design brief into a polished, self-contained HTML/SVG artifact (posters, infographics, landing pages, charts, component mockups) with a hard pre-delivery quality checklist and an anti-"AI-look" pattern list.

## Checklist

- [x] The repo carries the `#dsh` GitHub topic
- [x] I edited **both** `README.md` and `README.zh-CN.md`
- [x] Entry follows the format: `- [Name](url) — description.`
- [x] Description is factual and hype-free
- [x] The project is real, working, and publicly accessible