### PR TITLE
Add dsh-smooth-stream to UI / Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1217,6 +1217,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [mecoren/deepseek-harness-launcher](https://github.com/mecoren/deepseek-harness-launcher) — A launcher for DeepSeek Harness (no description provided upstream).
 - [cupen/dsh-workbench](https://github.com/cupen/dsh-workbench) — A workbench plugin for DeepSeek Harness.
 - [lee259/dsh-workbench](https://github.com/lee259/dsh-workbench) — Right-side file workspace for DeepSeek Harness Web.
+- [Laplace-bit/dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) — Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and respects prefers-reduced-motion.
 
 ## Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1202,6 +1202,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [mecoren/deepseek-harness-launcher](https://github.com/mecoren/deepseek-harness-launcher) —— DeepSeek Harness 启动器（上游无描述）。
 - [cupen/dsh-workbench](https://github.com/cupen/dsh-workbench) —— DeepSeek Harness 工作台插件。
 - [lee259/dsh-workbench](https://github.com/lee259/dsh-workbench) —— DeepSeek Harness Web 的右侧文件工作区。
+- [Laplace-bit/dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) —— 丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 prefers-reduced-motion。
 
 ## Skill
 


### PR DESCRIPTION
Add [dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) under **UI / Clients**: silky streaming reveal for the DSH Web UI.

- `package.json` declares `dsh.bundle.patch` (`cordis.patch.yml`) and `dsh.client.platform: web`.
- Repo carries the `dsh` topic and `dsh-plugin` topic.
- Official `@deepseek-ai/*` packages declared as `peerDependencies`.
- Both `README.md` and `README.zh-CN.md` updated and kept in sync.