### PR TITLE
Add dsh-netcafe — hosted MCP outcome tools (China vantage, tables, doc flow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,7 @@ _Long-running loop workflows: auto-research, deep-research, self-refine, iterati
 _Model Context Protocol servers that contribute tools / prompts / resources to DSH._
 
 <!-- Add entries here. -->
+- [dsh-netcafe](https://github.com/mario03690/dsh-netcafe) — Hosted outcome tools over MCP: doc/PDF conversion, tables with in-code arithmetic checks, China-reachability testing from a real mainland vantage (+ live README badge & 30-day watch), Chinese calendar/holidays. Free anonymous quota, per-call cost reporting. *(Disclosure: by the ainetcafe.com team.)*
 - [Chhlafiu4312/dsh-mcp-bridge](https://github.com/Chhlafiu4312/dsh-mcp-bridge) — Zero-dependency MCP client bridge for DSH: connects stdio/HTTP MCP servers and auto-registers their tools as `mcp_<server>_<tool>`; raw JSON-RPC 2.0, bounded auto-reconnect, installable via `dsh plugin add`.
 - [bobleer/deepseek-harness-plugin-mcp](https://github.com/bobleer/deepseek-harness-plugin-mcp) — MCP server that lets any agent (Cursor, Claude Code, Codex) discover, install, and run DSH plugins from the `dsh-plugin` topic.
 - [chenyinrusi/dsh-repo-health](https://github.com/chenyinrusi/dsh-repo-health) — Read-only repository health scanners for DeepSeek Harness: definition drift, unwired-module reachability, prompt bloat, evidence-gate calibration, and registration completeness; CLI + MCP server.


### PR DESCRIPTION
Adds dsh-netcafe under MCP Servers: a thin Cordis bundle wiring AI NetCafé's hosted MCP tools into dsh (ships cordis.patch.yml; touches only the MCP client config shape, compatible with the v0.1 preview). Notable: China-reachability testing from a real mainland backbone (+ daily-refreshed README badge and a 30-day watch), tables with in-code arithmetic verification, md→docx/pptx/pdf. Free anonymous quota; every response reports its exact cost. Disclosure: we run ainetcafe.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)