### PR TITLE
Add organize-workspace-sessions (DSH workspace session organizer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,6 +1224,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 ## Skills
 
 _Packaged task capabilities (markdown-based skills, tool packs)._
+- [caoqinnan-web/organize-workspace-sessions](https://github.com/caoqinnan-web/organize-workspace-sessions) — Organize DeepSeek Harness workspace sessions: rename them as Category｜Topic via the host's local RPC (workspace.list / session.list / session.history / session.rename) and report archive/rename/judgment suggestions — no archiving, because DSH has no archive-view entry.
 - [chenyinrusi/dsh-engineering-skills](https://github.com/chenyinrusi/dsh-engineering-skills) — Five engineering-discipline skills for AI coding agents (DeepSeek Harness, Claude Code, Codex): 18-dimension code review, CI failure triage, shell safety, redundancy/boundary audit, and cross-repo pattern absorption — pure markdown, no install.
 - [write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay) — Chinese long-form screenwriting skill (SKILL.md): two input blocks + causal-value engine with anti-AI-flavor review and a continuity ledger for 100+ scene projects.
 - [gongyijie85/dsh-ponytail](https://github.com/gongyijie85/dsh-ponytail) — Ponytail, lazy senior dev mode, for DSH: 6 skills (ponytail, ponytail-audit, ponytail-debt, ponytail-gain, ponytail-help, ponytail-review) adapted from DietrichGebert/ponytail (MIT).


### PR DESCRIPTION
## Summary

Add [caoqinnan-web/organize-workspace-sessions](https://github.com/caoqinnan-web/organize-workspace-sessions) to the Skills list.

A DeepSeek Harness Skill that organizes the current workspace's sessions — renames every visible session to `类别｜主题` (Category｜Topic) through the host's local RPC (`workspace.list` / `session.list` / `session.history` / `session.rename`) and reports archive/rename/judgment suggestions.

Notes:
- It does **not** archive anything, because DSH currently has no archive-view entry; safe-to-archive candidates are listed as suggestions only.
- Compatibility: DSH ✅ supported, ChatGPT ✅ supported, Claude ❌ tested but not supported.
- The repo carries the `dsh` topic.
