### PR TITLE
Add dsh-whale-meter to Cost & Usage Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ _Token usage, cost dashboards, and budget-alert plugins._
 - [y2zyyr/dsh-token-usage-sidebar](https://github.com/y2zyyr/dsh-token-usage-sidebar) — Persistent Today / Yesterday / Total token usage sidebar for DeepSeek Harness.
 - [Ycet/dsh-account-usage](https://github.com/Ycet/dsh-account-usage) — Adds a "Settings: Account" page to dsh, allowing quick viewing of DeepSeek balance, usage information, and OpenCode Go quota details, while also providing quick links to the respective official websites.
 - [534119219/chicheng-stats](https://github.com/534119219/chicheng-stats) — Global usage-stats plugin: sidebar panel showing today's/total request counts and today's/total token counts across all sessions.
+- [Shiye-10Pages/dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) — Usage tiers (🐟→🐳) by monthly token burn with a locally-estimated percentile and shareable stats card; 46 models across 6 vendors including size-tiered Chinese pricing; backfills pre-install sessions; separate old/new rates across the 2026-08-17 price change.
 ## Channel / IM Bridges
 
 _Bridges DSH into chat platforms and messaging channels._

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -415,6 +415,7 @@ _token 用量、成本看板与预算告警插件。_
 - [y2zyyr/dsh-token-usage-sidebar](https://github.com/y2zyyr/dsh-token-usage-sidebar) —— DeepSeek Harness 的持久化侧边栏：今日/昨日/总计 token 用量。
 - [Ycet/dsh-account-usage](https://github.com/Ycet/dsh-account-usage) —— 为 dsh 增加「设置：账户」页面，可快捷查看 deepseek 余额、用量信息，以及 opencode go 额度信息，同时可快速跳转至对应官网。
 - [534119219/chicheng-stats](https://github.com/534119219/chicheng-stats) —— dsh 全局用量统计插件：侧边栏展示今日/总请求数与今日/总 Token 数（跨所有会话）。
+- [Shiye-10Pages/dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) —— 按本月 token 消耗评 🐟→🐳 五档段位，分位本地估算并附可分享战绩卡；6 家厂商 46 个模型精准计价，含国内按输入长度分档；回填安装前的会话；8·17 调价前后各按各价。
 
 ## Channel / IM 桥接
 


### PR DESCRIPTION
Adds [dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) under **Cost & Usage Tracking**, in both `README.md` and `README.zh-CN.md` (kept in sync, Chinese file uses the ` —— ` separator).

Factual description of what it does, since there are already several cost plugins in this section:

- **Usage tiers** — 🐟→🐳 by monthly token burn, with a shareable stats card. The percentile is computed locally from a distribution curve committed in the repo and is labelled an estimate; the plugin uploads nothing, so a true global ranking isn't something it can claim.
- **46 models across 6 vendors** (DeepSeek, Anthropic, OpenAI, Google, Zhipu GLM, Moonshot Kimi), each checked against the vendor's official pricing page — including **size-tiered Chinese pricing**, e.g. GLM-5.1 bills ¥6/M under 32K input and ¥8/M above, and GLM-4.7 splits three ways by output length.
- **Backfill** — imports sessions from before the plugin was installed via a read-only pass over dsh session logs.
- **Rate-change aware** — prices are organised by effective period, so usage on 08-16 bills at the old DeepSeek rates and 08-17 at the new ones instead of retroactively rewriting history.

Public, MIT, installable via `dsh plugin add dsh-whale-meter` (npm). Data stays local in `~/.dsh/whale-meter/*.jsonl`; no telemetry.

Note on the `#dsh` topic requirement: the repo currently carries `dsh-plugin`, `deepseek-harness`, `dsh` and related topics — happy to adjust if you need a different exact tag.