### PR TITLE
Add FlashingChen/dsh-desktop-hub to UI / Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [cupen/dsh-workbench](https://github.com/cupen/dsh-workbench) — A workbench plugin for DeepSeek Harness.
 - [lee259/dsh-workbench](https://github.com/lee259/dsh-workbench) — Right-side file workspace for DeepSeek Harness Web.
 - [Laplace-bit/dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) — Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and respects prefers-reduced-motion.
+- [FlashingChen/dsh-desktop-hub](https://github.com/FlashingChen/dsh-desktop-hub) — Electron desktop hub for the official DSH Web UI with a built-in MCP config converter (Claude Code / Cursor JSON → DSH YAML), Skills / Plugin management consoles, and a bundled Node.js + DSH runtime (no install, no terminal).
 
 ## Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1204,6 +1204,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [cupen/dsh-workbench](https://github.com/cupen/dsh-workbench) —— DeepSeek Harness 工作台插件。
 - [lee259/dsh-workbench](https://github.com/lee259/dsh-workbench) —— DeepSeek Harness Web 的右侧文件工作区。
 - [Laplace-bit/dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) —— 丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 prefers-reduced-motion。
+- [FlashingChen/dsh-desktop-hub](https://github.com/FlashingChen/dsh-desktop-hub) —— 官方 DSH Web UI 的 Electron 桌面中枢：内置 MCP 配置转换器（Claude Code / Cursor JSON 一键转 DSH YAML）与 Skills / Plugin 管理台，捆绑 Node.js + DSH 运行时，免安装、免终端。
 
 ## Skill
 


### PR DESCRIPTION
Adds [FlashingChen/dsh-desktop-hub](https://github.com/FlashingChen/dsh-desktop-hub) to the UI / Clients section.

Electron desktop hub for the official DSH Web UI with a built-in **MCP config converter** (Claude Code / Cursor JSON → DSH YAML, paste-and-go), Skills and Plugin management consoles, and a bundled Node.js + DSH runtime (no install, no terminal). Repo carries the `#dsh` topic.

README.md and README.zh-CN.md updated.