### PR TITLE
docs: add WayneJin0918/dsh-wm to Loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,7 @@ _Long-running loop workflows: auto-research, deep-research, self-refine, iterati
 - [jingzhao-l/iterate-plugin](https://github.com/jingzhao-l/iterate-plugin) — DeepSeek Harness (dsh) plugin: turns the iterate skill into an autonomous closed-loop code iteration — multi-round parallel review, deterministic dedup convergence, atomic fix + verify self-stop, meta-review consistency audit, dry-run read-only review. Maintained by the iterate-skill main repo.
 - [lmzhen/dsh-evolution](https://github.com/lmzhen/dsh-evolution) — Hermes-inspired agent self-evolution plugin family, purpose-built for DeepSeek Harness.
 - [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) — Evidence-first, crash-resumable self-evolution engine: bounded Cordis candidate generation, one-shot real-Loader admission, Harbor evaluation, and an auditable journaled lineage.
+- [WayneJin0918/dsh-wm](https://github.com/WayneJin0918/dsh-wm) — World-model research toolkit: inspect frames, name 3D / pixel / latent routes, score pred vs GT, and RSI skills / wm.yaml.
 
 ## MCP Servers
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -852,6 +852,7 @@ _长时运行的循环工作流：自动研究、深度调研、自我精炼、�
 - [jingzhao-l/iterate-plugin](https://github.com/jingzhao-l/iterate-plugin) —— DeepSeek Harness (dsh) 插件：把 iterate 技能落成自治闭环代码迭代——多轮并行审查、确定性去重收敛、原子修复+验证自停、meta-review 一致性审计、dry-run 只读审查。由 iterate-skill 主仓库统一维护。
 - [lmzhen/dsh-evolution](https://github.com/lmzhen/dsh-evolution) —— 受 Hermes 启发的 agent 自进化插件族谱，专为 DeepSeek Harness 打造。
 - [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) —— 证据优先、可崩溃恢复的自进化引擎：有界 Cordis 候选生成、一次性真实 Loader 准入、Harbor 评估，以及可审计的日志化谱系。
+- [WayneJin0918/dsh-wm](https://github.com/WayneJin0918/dsh-wm) —— 世界模型研究插件：看帧、认 3D / pixel / latent 路线、给 pred vs GT 打分，并对 skill / wm.yaml 做 RSI。
 
 ## MCP Server
 


### PR DESCRIPTION
## Summary
- Add [WayneJin0918/dsh-wm](https://github.com/WayneJin0918/dsh-wm) under **Loops (Auto-Research, Self-Improve, etc.)**.
- Repo is public and tagged `#dsh` / `#dsh-plugin` / `#deepseek-harness`.
- Factual one-liner: inspect frames, name 3D / pixel / latent routes, score pred vs GT, RSI skills / `wm.yaml`.

Install: `dsh plugin --profile wm add github:WayneJin0918/dsh-wm`

Official share: https://github.com/deepseek-ai/deepseek-harness/discussions/2618

Made with [Cursor](https://cursor.com)