### PR TITLE
docs: add sjh9714/dsh-what-changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 
 - [reshuibuduo/TMCRA-Agent-Memory](https://github.com/reshuibuduo/TMCRA-Agent-Memory) — Technical-preview owner-local graph memory for DSH and Codex: recalls owner-global and current-project evidence before each turn, keeps USER and ASSISTANT records separate, and preserves project, session, actor, and source provenance.
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
+- [sjh9714/dsh-what-changed](https://github.com/sjh9714/dsh-what-changed) — Session-wide file change review in the session header. Lists every file the agent wrote this session with its hunks, counts refused writes separately from changes, and folds from a session projection rather than the on-disk log.
 - [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) — Bounded cross-session memory backed by SQLite.
 - [Spirtxiaoqi7/mindspace-dsh-session-memory](https://github.com/Spirtxiaoqi7/mindspace-dsh-session-memory) — Session-isolated personalized memory.
 - [PerryLink/dsh-checkpoint-rewind](https://github.com/PerryLink/dsh-checkpoint-rewind) — Git-snapshot checkpoints with a `/rewind` command.


### PR DESCRIPTION
Adds `dsh-what-changed` to Sessions & Storage in both language versions.

Per-call diff cards already render, so what is missing is the session-wide answer you want before committing, which files ended up changed. It puts a button in the session header with the file and edit counts and opens to a per-file review.

It registers a unit with `ctx.sessionProjections`. No core file is modified, no on-disk log is parsed, no events are subscribed to.

A write the permission fence refused is counted against its file and kept out of the edit total, since showing a refusal as a change recreates the problem the plugin exists to remove. A `tool/result` carrying the hunk the tool actually applied is preferred over the call arguments, and each edit records which of the two it came from.

Published on npm and verified in a live `dsh web` session against a real model. CI runs typecheck, tests and the build on Linux, macOS and Windows.

- Repo https://github.com/sjh9714/dsh-what-changed
- npm https://www.npmjs.com/package/dsh-what-changed
