### PR TITLE
Add chenproton/dsh-history plugin (Session & Memory Management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [szx-a/ds](https://github.com/szx-a/ds) — dsh Memory Body plugin: cross-session memory with multiple named bodies, per-session mounting, auto-summarization, and FTS5 full-text search (trigram tokenizer for Chinese).
 - [quicksandznzn/dsh-session-bridge](https://github.com/quicksandznzn/dsh-session-bridge) — Share and import complete DeepSeek Harness Session trees as validated, offline Capsules with local ZIP transfer and attachment remapping.
 - [SiriLee/dsh-rewind](https://github.com/SiriLee/dsh-rewind) — DeepSeek Harness plugin: in-place conversation rewind in the same session window (Claude Code /rewind semantics) + optional file restore.
+- [chenproton/dsh-history](https://github.com/chenproton/dsh-history) — Browse every message you sent in the current session: full-history listing with newest-first sort, text filter, one-click copy, and click-to-jump that auto-loads earlier history when the target is not yet loaded.
 
 ## Cost & Usage Tracking
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -421,6 +421,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [szx-a/ds](https://github.com/szx-a/ds) —— dsh 记忆体（Memory Body）插件：跨会话记忆，支持多个命名记忆体、按会话挂载、自动总结，以及 FTS5 全文检索（trigram 分词器适配中文）。
 - [quicksandznzn/dsh-session-bridge](https://github.com/quicksandznzn/dsh-session-bridge) —— deepseek,deepseek-harness,dsh,dsh-plugin,dsh-plugins。将完整的 DeepSeek Harness 会话树导出/导入为可验证的离线 Capsule，支持本地 ZIP 传输与附件重新映射。
 - [SiriLee/dsh-rewind](https://github.com/SiriLee/dsh-rewind) —— DeepSeek Harness 插件：在同一会话窗口内原地回滯对话（Claude Code /rewind 语义）+ 可选文件还原。
+- [chenproton/dsh-history](https://github.com/chenproton/dsh-history) —— 会话历史消息查看：列出当前会话全部你发送的消息，支持最新在前排序、文本过滤、一键复制，点击可跳转定位（目标未加载时自动加载更早历史）。
 
 ## 成本与用量统计
 


### PR DESCRIPTION
Adds [chenproton/dsh-history](https://github.com/chenproton/dsh-history) to the Session & Memory Management section.

The plugin lists every user-sent message in the current conversation (full history, including pages not yet loaded), with newest-first sort toggle, text filter, one-click copy, and click-to-jump that auto-loads earlier history when the target is outside the loaded window.

Repo carries the `dsh-plugin` topic; installable via `dsh plugin --profile web add dsh-history`.