### PR TITLE
Add obsidian-knowledge-mode to Profiles & Patch Layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ _DSH's core composition mechanism: a **profile** stacks bundle patch layers, the
 - [delightedMaster/dsh-anchored-standard-windows](https://github.com/delightedMaster/dsh-anchored-standard-windows) — Windows Anchored Standard agent preset for DeepSeek Harness with on-demand tools and Skills.
 - [delightedMaster/dsh-subprocess-win32](https://github.com/delightedMaster/dsh-subprocess-win32) — Windows subprocess Cordis runtime and Minimal/Anchored Standard presets for DeepSeek Harness.
 - [brunhildzhou/dsh-all-warmup](https://github.com/brunhildzhou/dsh-all-warmup) — Global frictionless warm-up layer plugin for DeepSeek Harness: the first turn of any session auto-warms up, full mode resumes from the second turn on.
+- [jiatong-lab914/obsidian-knowledge-mode](https://github.com/jiatong-lab914/obsidian-knowledge-mode) — DSH agent preset for a portable, AI-native knowledge system on Obsidian: anti-hoarding Layer 0, 80/20 distillation into Context/Claim, verifiable update loops, four read-only role agents, a source gate hook, and a zero-content starter template.
 
 ## Harnesses & Runtimes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,6 +80,7 @@ _DSH 的核心组合机制：一个 **profile** 叠加各 bundle 的 patch 层�
 - [delightedMaster/dsh-anchored-standard-windows](https://github.com/delightedMaster/dsh-anchored-standard-windows) —— 面向 DeepSeek Harness 的 Windows Anchored Standard agent 预设，按需加载工具与 Skills。
 - [delightedMaster/dsh-subprocess-win32](https://github.com/delightedMaster/dsh-subprocess-win32) —— DeepSeek Harness 的 Windows subprocess Cordis 运行时与 Minimal/Anchored Standard 预设。
 - [brunhildzhou/dsh-all-warmup](https://github.com/brunhildzhou/dsh-all-warmup) —— DeepSeek Harness 全局无感热身层插件：任何会话首轮自动热身，第二轮起恢复完整模式。
+- [jiatong-lab914/obsidian-knowledge-mode](https://github.com/jiatong-lab914/obsidian-knowledge-mode) —— Obsidian 可携带、AI-native 的知识系统 DSH agent preset：反收藏夹 Layer 0、二八提炼为 Context/Claim、可验证的更新环、四个只读角色代理、外部来源 Gate 钩子与零内容 starter 模板。
 
 ## Harness 与运行时
 


### PR DESCRIPTION
Add [obsidian-knowledge-mode](https://github.com/jiatong-lab914/obsidian-knowledge-mode) — a DSH agent preset for a portable, AI-native knowledge system on Obsidian.

What it includes:
- Anti-hoarding Layer 0 (80% stays raw, only ~20% distilled into Context/Claim)
- Verifiable update loops (replaced/replaces versioning)
- 4 read-only role agents: red-team, defense, researcher, verifier
- Source gate hook (mechanical write guard for external sources)
- Zero-content starter template + QUICKSTART for onboarding
- MIT license

Repo carries the `#dsh` topic. Added one line to both README.md and README.zh-CN.md under Profiles & Patch Layers.