### PR TITLE
Add dsh-turn-cost (per-turn CNY cost badge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 _Token usage, cost dashboards, and budget-alert plugins._
 
 - [boNeXY226/dsh-cost-chip](https://github.com/boNeXY226/dsh-cost-chip) — `/cost` command plus a floating cost chip showing session spend.
+- [WFMinerva/dsh-turn-cost](https://github.com/WFMinerva/dsh-turn-cost) — Per-turn real cost under every assistant reply: CNY at official peak/off-peak rates with cache-hit ratio; fully local, zero telemetry.
 - [misakimiku2/dsh-cost-display](https://github.com/misakimiku2/dsh-cost-display) — Displays session cost.
 - [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) — Cost ledger tracking spend over time.
 - [csiroqa/dsh-plugin-usage-report](https://github.com/csiroqa/dsh-plugin-usage-report) — Daily/monthly usage reports: tokens, cost, budget alerts, and a contribution-graph view.


### PR DESCRIPTION
Hello! Thanks for maintaining this list.

I'd like to submit a small plugin for inclusion:

- Repo: https://github.com/WFMinerva/dsh-turn-cost
- What it does: shows the real per-turn cost under every assistant reply in the dsh web UI — CNY at the official DeepSeek peak/off-peak rates (2026-08-17 card), with token count and cache-hit ratio. It folds provider-reported usage from local session logs; fully local, zero telemetry, no API keys involved.

Added one line under **Cost & Usage Tracking**. Happy to adjust the wording if needed. Thanks!