### PR TITLE
Add dsh-memory-porter (Session & Memory Management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [Scorp1o117/dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) — Agent memory plugin for DeepSeek Harness.
 - [wonderfulcode1/dsh-checkpoint-diff](https://github.com/wonderfulcode1/dsh-checkpoint-diff) — File-diff visualization between checkpoint time nodes for DeepSeek Harness: read-only timeline + per-file line diff over dsh-checkpoint-rewind checkpoints, as a `/diff` command, JSON HTTP API, and GUI panel.
 - [Zh-U-hB/dsh-auto-compact](https://github.com/Zh-U-hB/dsh-auto-compact) — Automatic threshold-triggered compaction (default 256K) for every session and agent preset.
+- [dsh-memory-porter](https://github.com/Shiye-10Pages/dsh-memory-porter) — Cross-vendor memory migration into DSH: zero-token import of the `memories.json` in a Claude export, local Claude Code transcripts without an export, and conversations distilled through the model already configured in DSH, with verbatim evidence checked against the source by code.
 
 ## Cost & Usage Tracking
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -339,6 +339,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [Scorp1o117/dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) —— DeepSeek Harness 记忆插件。
 - [wonderfulcode1/dsh-checkpoint-diff](https://github.com/wonderfulcode1/dsh-checkpoint-diff) —— DeepSeek Harness 检查点时间节点间的文件 diff 可视化：只读时间线 + 基于 dsh-checkpoint-rewind 检查点的逐文件行级 diff，提供 `/diff` 命令、JSON HTTP API 与 GUI 面板。
 - [Zh-U-hB/dsh-auto-compact](https://github.com/Zh-U-hB/dsh-auto-compact) —— DeepSeek Harness 插件：每个会话与 agent 预设自动阈值触发压缩（默认 256K）。
+- [dsh-memory-porter](https://github.com/Shiye-10Pages/dsh-memory-porter) — 跨厂商记忆迁移：Claude 导出里的 `memories.json` 零 token 入库、本机 Claude Code 记录免导出直读、历史对话用 DSH 里已配好的模型提纯，每条记忆都带由代码回原文核对的逐字证据。
 
 ## 成本与用量统计
 


### PR DESCRIPTION
Added to both `README.md` and `README.zh-CN.md`, kept in sync, using the `- [Name](link) — description.` format.

**What it does**: brings existing Claude / ChatGPT history into DSH. Three paths — the `memories.json` inside a Claude account export (already distilled, so zero tokens and instant), local Claude Code transcripts with no export needed, and conversations distilled through whichever model the user already configured in DSH, so no extra API key.

**Why it is different**: every memory must carry verbatim evidence, and that evidence is checked against the source text **by code** rather than taken on the model's word. In a real run over a 7-conversation export, 6 of 25 candidates were rejected for not matching; evidence found only in the assistant's turns is routed to review instead of stored, since a restatement is not the user's own words.

MIT, on npm as `dsh-memory-porter`, zero runtime dependencies, `dsh` and `dsh-plugin` topics present.