### PR TITLE
Add dsh-llm-local-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [daifuyang/dsh-plugin](https://github.com/daifuyang/dsh-plugin) — Community plugin bundles for dsh (DeepSeek Harness) — login, metrics, and other Cordis bundles.
 - [loongsuite/pilot-dsh](https://github.com/loongsuite/pilot-dsh) — DeepSeek Harness (dsh) plugin for LoongSuite Pilot: records session, LLM, and tool events to local JSONL for OpenTelemetry GenAI traces.
 - [QvShui/dsh-llm-qwen](https://github.com/QvShui/dsh-llm-qwen) — Qwen (DashScope) LLM provider adapter plugin for DeepSeek Harness.
+- [tianxia--/dsh-llm-local-token](https://github.com/tianxia--/dsh-llm-local-token) — LLM provider plugin that reuses local Codex CLI and Claude Code OAuth tokens instead of separate API keys.
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) — Codex App Server model provider for DeepSeek Harness, using your local Codex login.
 
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -202,6 +202,7 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [daifuyang/dsh-plugin](https://github.com/daifuyang/dsh-plugin) —— dsh（DeepSeek Harness）社区插件合集：登录、指标等 Cordis 插件包。
 - [loongsuite/pilot-dsh](https://github.com/loongsuite/pilot-dsh) —— LoongSuite Pilot 的 DeepSeek Harness 插件：把会话、LLM 与工具事件记录到本地 JSONL，供 OpenTelemetry GenAI 链路追踪。
 - [QvShui/dsh-llm-qwen](https://github.com/QvShui/dsh-llm-qwen) —— Qwen（DashScope）LLM 适配器插件。
+- [tianxia--/dsh-llm-local-token](https://github.com/tianxia--/dsh-llm-local-token) —— 复用本机 Codex CLI 与 Claude Code 的 OAuth 凭据，为 DeepSeek Harness 提供 LLM 路由，无需单独配置 API key。
 - [wss534857356/dsh-plugin-codex](https://github.com/wss534857356/dsh-plugin-codex) —— 使用本地 Codex 登录态接入 Codex App Server 的模型供应商插件。
 
 


### PR DESCRIPTION
## What are you adding?

- **Name:** tianxia--/dsh-llm-local-token
- **Link:** https://github.com/tianxia--/dsh-llm-local-token
- **Category:** Harnesses & Runtimes
- **One-line description:** LLM provider plugin that reuses local Codex CLI and Claude Code OAuth tokens instead of separate API keys.

Adds a DeepSeek Harness provider plugin for routing through local Codex CLI and Claude Code OAuth credentials, with provider usage derived from rate-limit headers.
Repo: https://github.com/tianxia--/dsh-llm-local-token
Release v1.2.0: https://github.com/tianxia--/dsh-llm-local-token/releases/tag/v1.2.0
I followed CONTRIBUTING.md and updated both README files only.

## Checklist

- [x] The repo carries the `#dsh` GitHub topic
- [x] I edited **both** `README.md` and `README.zh-CN.md`
- [x] Entry follows the format: `- [Name](url) — description.`
- [x] Description is factual and hype-free
- [x] The project is real, working, and publicly accessible
