### PR TITLE
feat: add Living-Dream-DSH to Profiles & Patch Layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ _DSH's core composition mechanism: a **profile** stacks bundle patch layers, the
 - [delightedMaster/dsh-subprocess-win32](https://github.com/delightedMaster/dsh-subprocess-win32) — Windows subprocess Cordis runtime and Minimal/Anchored Standard presets for DeepSeek Harness.
 - [brunhildzhou/dsh-all-warmup](https://github.com/brunhildzhou/dsh-all-warmup) — Global frictionless warm-up layer plugin for DeepSeek Harness: the first turn of any session auto-warms up, full mode resumes from the second turn on.
 - [jiatong-lab914/obsidian-knowledge-mode](https://github.com/jiatong-lab914/obsidian-knowledge-mode) — DSH agent preset for a portable, AI-native knowledge system on Obsidian: anti-hoarding Layer 0, 80/20 distillation into Context/Claim, verifiable update loops, four read-only role agents, a source gate hook, and a zero-content starter template.
+- [alllllllllli/Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) — Complete DSH desktop config framework: 8+ MCP servers (computer-use, browser, memory, OCR, vision, history, markitdown, os-copilot), free model channels (CNB proxy, AMD Radeon Cloud), mobile remote via Tailscale, vision patches (GLM-4V-Flash → Ollama fallback), and a one-click installer (PowerShell + offline 120 MB SFX). MIT.
 
 ## Harnesses & Runtimes
 


### PR DESCRIPTION
Add Living-Dream-DSH to Profiles & Patch Layers section.

- 8+ MCP servers (computer-use, browser, memory, OCR, vision, history, markitdown, os-copilot)
- Free model channels (CNB proxy, AMD Radeon Cloud)
- Mobile remote via Tailscale
- Vision patches (GLM-4V-Flash to Ollama fallback)
- One-click PowerShell installer + offline 120MB SFX
- License: MIT