### PR TITLE
Add opencues/opencues to UI / Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,7 @@ _Multi-step / multi-agent schedulers and output aggregators._
 
 ## UI / Clients
 
+- [opencues/opencues](https://github.com/opencues/opencues/tree/master/integrations/dsh) — Word alternatives and underscore-gated fill-ins in the composer: end a line with `_` and it is filled, misspellings flagged as you type; uses the model dsh is already configured with, so no API key.
 - [Zhangbo-cn/dsh-voice-input-plugin](https://github.com/Zhangbo-cn/dsh-voice-input-plugin) — Composer mic for the Web UI: tap-to-monitor live transcription and hold-to-talk, with host Edge TTS reply reading that streams while the model generates, echo-pause during reading, and tap-to-stop.
 
 _Desktop, web, terminal, or editor front-ends for DSH._

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1057,6 +1057,7 @@ _多步 / 多 agent 调度器与输出聚合器。_
 _DSH 的桌面、网页、终端或编辑器前端。_
 
 - [EthanYoQ/AI-Novel-Writer](https://github.com/EthanYoQ/AI-Novel-Writer) —— 本地优先的长篇小说桌面工作台，并提供 DeepSeek Harness 插件开发预览，用于修订式小说项目编辑。
+- [opencues/opencues](https://github.com/opencues/opencues/tree/master/integrations/dsh) —— 输入框内的同义词提示与下划线补全：行尾输入 `_` 即自动填充，拼写错误随打随标；直接使用 dsh 已配置的模型，无需自备 API key。
 - [zhu1090093659/dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) —— DSH Web UI 插件与皮肤合集：任务看板、git graph、右侧面板、远程移动端 UI、宠物、实时 token 统计与皮肤中心。  `⭐506`
 - [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) —— DeepSeek Harness 终端 UI（天枢 TUI）。  `⭐73`
 - [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) —— 侧边栏完整工作台：支持三方扩展注册新 Tab，内置文件渲染编辑 / 终端 / Git / 子代理。  `⭐127`


### PR DESCRIPTION
One entry under **UI / Clients**, in both `README.md` and `README.zh-CN.md`.

OpenCues puts word alternatives and underscore-gated fill-ins in the composer: end a line with `_` and it is filled, misspellings are flagged as you type. It uses whichever model dsh is already configured with, so it needs no API key of its own.

Install: `dsh plugin --profile web add @opencues/dsh` — published to npm with the browser bundle prebuilt, so it skips pnpm's `allowBuilds` build-approval step.

Against the checklist in CONTRIBUTING.md:

1. **`#dsh` topic** — added to `opencues/opencues` (it also carries `dsh-plugin`).
2. **Both files edited and kept in sync** — English uses ` — `, Chinese uses ` —— `, per the note in the guide.
3. **Exact entry format**, placed alphabetically within the section.
4. **Factual and hype-free** — it describes the two gestures and the fact that it needs no key, nothing more.

It is a monorepo, so the link points at the plugin's own directory rather than the repo root. Verified end to end against the published package on a clean machine — no `.cues` config, no API keys in the environment — where `the capital of iceland is _` fills to `Reykjavik` on DeepSeek's own model.