### PR TITLE
Add xuanyuying/dsh-desktop and xuanyuying/dsh-mobile to UI/Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,8 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [Missher12/deepseek-harness-desktop](https://github.com/Missher12/deepseek-harness-desktop) — Unofficial desktop client.
 - [ningbainb/deepseek-harness-desktop](https://github.com/ningbainb/deepseek-harness-desktop) — Unofficial desktop client.
 - [xccElephant/deepseek-harness-desktop](https://github.com/xccElephant/deepseek-harness-desktop) — Unofficial desktop client.
+- [xuanyuying/dsh-desktop](https://github.com/xuanyuying/dsh-desktop) — Electron desktop app for DeepSeek Harness: one-click launch of the full Web UI, real-time account balance display, and offline packaging for China networks.
+- [xuanyuying/dsh-mobile](https://github.com/xuanyuying/dsh-mobile) — Mobile PWA client for DeepSeek: streaming chat with Markdown rendering, multi-session, voice input, reasoning display, balance widget, and GitHub Pages deployment.
 - [Tom6814/dsh-web](https://github.com/Tom6814/dsh-web) — Docker-based web deployment.
 - [skitse/dsh-dev-actions](https://github.com/skitse/dsh-dev-actions) — One-click shortcuts for common dev commands.
 - [Wine-Red/dsh-prompt-stash](https://github.com/Wine-Red/dsh-prompt-stash) — Stash and recall prompts.


### PR DESCRIPTION
## What

Add two DSH ecosystem clients to the **UI / Clients** section:

1. **xuanyuying/dsh-desktop** - Electron desktop app for DeepSeek Harness: one-click launch of the full Web UI, real-time account balance display, and offline packaging for China networks.
2. **xuanyuying/dsh-mobile** - Mobile PWA client for DeepSeek: streaming chat with Markdown rendering, multi-session, voice input, reasoning display, balance widget, and GitHub Pages deployment.

## Checklist

- [x] Both repos carry the #dsh GitHub topic
- [x] Entries added under the most fitting category (UI / Clients)
- [x] Format: - [Name](https://link) - Concise one-line description.
- [x] One PR per logical change; descriptions factual