### PR TITLE
Add dsh-meme-hub to Orchestrators & Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,8 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [Chinesezjc/dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) — Cross-instance message/event handoff plugins for DSH (interconnect service + tools).  `⭐15`
 - [titanwings/dsh-automation](https://github.com/titanwings/dsh-automation) — Runs coding tasks on a schedule in fresh agent sessions; schedules are managed from the DSH Web UI or by the agent itself.
 - [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — Side sessions: persistent `/side` sessions (Codex-style) and one-shot `/btw` questions (Claude-style) that run in a temporary fork without touching main-session history, with an embedded side panel.
-- [omdsh-dev/dsh-hub-workshop](https://github.com/omdsh-dev/dsh-hub-workshop) — Public catalog, review projection, and immutable feed authority for the OMDSH ecosystem.
+- [omdsh-dev/dsh-hub-workshop](https://github.com/omdsh-dev/dsh-hub-workshop)
+- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) — Community-curated plugin directory for DeepSeek Harness: 340+ plugins across 14 categories, four languages, and a meme zone that is the whole point. — Public catalog, review projection, and immutable feed authority for the OMDSH ecosystem.
 - [TtTRz/dsh-gatedflow](https://github.com/TtTRz/dsh-gatedflow) — Human-in-the-loop gated workflow engine.
 - [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) — ChatGPT OAuth and Codex models for DeepSeek Harness.
 - [ropon/dsh-plugin-clawrouters](https://github.com/ropon/dsh-plugin-clawrouters) — One-key ClawRouters plugin for DeepSeek Harness: chat, image, video, and web search.


### PR DESCRIPTION
Adds [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub), a community-curated plugin directory for DeepSeek Harness — 340+ plugins across 14 categories, four languages, plus a meme/absurd section. Placed next to the existing ecosystem-directory entry (dsh-hub-workshop) since it serves the same role: a browsable, human-curated index of the plugin ecosystem rather than a single plugin.