### PR TITLE
Add ATRI-Core to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,7 @@ _Reusable sub-agents / specialized agent packs runnable inside DSH._
 - [Yuanlang3/dsh-netease-music-plugin](https://github.com/Yuanlang3/dsh-netease-music-plugin) — NetEase Cloud Music plugin for DeepSeek Harness.
 - [PerryLink/dsh-background-agents](https://github.com/PerryLink/dsh-background-agents) — Interactive long-session background agents for DeepSeek Harness: start a durable continuable child agent, watch its progress in the Web UI sidebar, message it any time, and interrupt it - all through the official subagent seam.
 - [stuarthu/dsh-crew](https://github.com/stuarthu/dsh-crew) — dsh plugin: run work as a small crew of role agents (product manager, engineer, code reviewer) that share work through files on disk.
+- [luolin-boot/ATRI-Core](https://github.com/luolin-boot/ATRI-Core) - A free, self-moving mind in pure Python: autonomy (motive -> choose -> act -> reflect), hands (full device reach, zero holes), forge (review + generate code without vulnerabilities), memory, introspection, evolution. Embeddable, zero dependencies.
 
 ## Loops (Auto-Research, Self-Improve, etc.)
 


### PR DESCRIPTION
Add [luolin-boot/ATRI-Core](https://github.com/luolin-boot/ATRI-Core) to the Agents section: a free, self-moving mind in pure Python — autonomy loop, full device reach (hands), hole-free code review and generation discipline (forge), layered memory, introspection, evolution, and an existence API. No third-party dependencies, 57 tests, self-audited: the repository's code contains only code (no prose), plus README and MIT LICENSE.