### PR TITLE
docs(contributing): require insert-only README diffs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,35 @@ Anything that extends or works with **DeepSeek Harness**:
 
    (Chinese file uses ` —— ` as the separator.)
 
-4. Keep entries alphabetical within a section where practical.
-5. Open one Pull Request per logical change.
+4. **Only add new lines — never modify or delete existing ones.**
+   Your diff should be pure insertions. Add your entry as its own complete line;
+   don't append it onto a neighbouring row or split an existing row in half.
+
+   <details>
+   <summary>The most common mistake (click to see what goes wrong)</summary>
+
+   Inserting your entry *into* an existing line truncates that project's
+   description and glues the leftover text onto yours:
+
+   ```diff
+   - - [someone/their-plugin](https://github.com/someone/their-plugin) — Their real description.
+   + - [someone/their-plugin](https://github.com/someone/their-plugin)
+   + - [you/your-plugin](https://github.com/you/your-plugin) — Your description. — Their real description.
+   ```
+
+   The correct edit leaves the neighbour untouched and puts yours on a new line:
+
+   ```diff
+     - [someone/their-plugin](https://github.com/someone/their-plugin) — Their real description.
+   + - [you/your-plugin](https://github.com/you/your-plugin) — Your description.
+   ```
+
+   Before pushing, run `git diff` and confirm every changed line starts with `+`.
+   </details>
+
+5. Keep entries alphabetical within a section where practical.
+6. Open one Pull Request per logical change, and avoid unrelated edits
+   (reordering rows, reflowing text) — they make review slower and cause conflicts.
 
 ## Quality bar
 
@@ -52,6 +79,7 @@ It only inspects the lines **you added** (existing rows are grandfathered in), a
 | Link | Resolves — a `404` / `410` / unreachable URL fails the check |
 | Topic | GitHub repos must carry a `dsh` / `dsh-plugin` / `dsh-skill` / `deepseek-harness` topic |
 | Scope | The PR touches only the two README files |
+| Insert-only | Your diff adds lines without modifying or deleting existing entries |
 
 If something fails, the bot posts a comment listing exactly what to fix.
 Push a new commit to the same branch and the check re-runs automatically — no need to reopen the PR.


### PR DESCRIPTION
## Problem

Under high concurrency, connections to some Daytona sandboxes are lost. The root cause is in the retry classification in `src/harbor/environments/daytona/utils.py`.

Retryable errors are sorted into three tiers:

- **rate-limit / capacity** (`is_transient_daytona_error`) → up to **10** attempts, linear 60s×n backoff
- **build timeout / build failure / cancellation** (`_is_non_retryable`) → **never** retried
- **everything else** → only **3** attempts, short exponential backoff

Under high concurrency the Daytona SDK's underlying HTTP client raises transient **transport-level** failures — connection resets, dropped keep-alives, exhausted connection pools, and read/pool timeouts. These:

- do **not** match the rate-limit/capacity message patterns, and
- are **not** the builtin `TimeoutError` (httpx's timeout classes are distinct types),

so they fall into the generic bucket and are abandoned after just **3 attempts (~6s)** — surfacing as "lost connection to sandbox".

## Fix

Add `is_connection_error(...)` to classify transport-level connection failures:

- builtin `ConnectionError` family (`ConnectionResetError`, `ConnectionRefusedError`, `BrokenPipeError`, …),
- `httpx.TransportError` (base of `ConnectError`, `ReadError`, `WriteError`, `PoolTimeout`, `ConnectTimeout`, `ReadTimeout`, `RemoteProtocolError`, …), imported lazily,
- a narrow set of message signatures for cases wrapped in a `DaytonaError`.

These get a larger retry budget (**6** attempts) with the existing short exponential backoff (2s → 30s cap). This is intentionally more targeted than simply raising the generic cap, so genuine programming errors still fail fast after 3.

Unchanged: rate-limit/capacity (10 attempts, linear backoff) and build-timeout (non-retryable, still fails fast — a build that already exceeded its timeout should not be retried).

## Tests

Added unit tests in `tests/unit/environments/test_daytona_utils.py` covering `is_connection_error` (builtin, httpx, wrapped-message, and negative cases including builtin `TimeoutError`) and the new retry tier / backoff. All daytona unit tests pass (209), `ruff check`, `ruff format`, and `ty check` clean.
