### PR TITLE
docs: add Star History chart to both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1816,6 +1816,16 @@ PRs welcome! To add a plugin:
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 
+## Star History
+
+<a href="https://star-history.com/#Dominic789654/awesome-deepseek-harness&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Dominic789654/awesome-deepseek-harness&type=Date&theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Dominic789654/awesome-deepseek-harness&type=Date">
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Dominic789654/awesome-deepseek-harness&type=Date" width="600">
+  </picture>
+</a>
+
 ## License
 
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1781,6 +1781,16 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 
 详见 [CONTRIBUTING.md](./CONTRIBUTING.md)。
 
+## Star 趋势
+
+<a href="https://star-history.com/#Dominic789654/awesome-deepseek-harness&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Dominic789654/awesome-deepseek-harness&type=Date&theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Dominic789654/awesome-deepseek-harness&type=Date">
+    <img alt="Star 趋势图" src="https://api.star-history.com/svg?repos=Dominic789654/awesome-deepseek-harness&type=Date" width="600">
+  </picture>
+</a>
+
 ## 许可
 
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
## What

Adds a **Star History** chart to the back matter of both READMEs.

- `README.md` → `## Star History`
- `README.zh-CN.md` → `## Star 趋势`

Placed after **Contributing** and before **License**, matching the usual awesome-list convention.

## Details

- Uses `<picture>` + `prefers-color-scheme` so the chart follows GitHub's light/dark theme instead of a white box in dark mode.
- Wrapped in a link to the interactive [star-history.com](https://star-history.com/#Dominic789654/awesome-deepseek-harness&Date) page.
- Width capped at `600` so it doesn't dominate the page on wide screens.
- **No TOC entry added** — the existing Contents list stops at Contributing and doesn't include License, so back-matter sections are intentionally unlisted. Adding one entry there would be inconsistent.

## Verification

| Check | Result |
| --- | --- |
| Light SVG returns 200 | ✅ `image/svg+xml`, 60,125 B |
| Dark SVG returns 200 | ✅ `image/svg+xml`, 60,140 B |
| Clickthrough page returns 200 | ✅ |
| Insert-only diff | ✅ +20 lines, 0 removals |
| Scope | ✅ only the two README files |

## Note

The repo was created 2026-08-13, so at ~133 stars the curve is still short and nearly vertical. It'll become more informative over time; the chart is generated live, so nothing needs updating later.

`starchart.cc` was the alternative but is currently rate-limiting (`HTTP 400 {"error":"rate limited"}`), so `star-history.com` is the safer dependency.
