### PR TITLE
Add hackerFish DSH ecosystem projects (skills / presets / lab / plugin list / video studio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ _DSH's core composition mechanism: a **profile** stacks bundle patch layers, the
 - [jiatong-lab914/obsidian-knowledge-mode](https://github.com/jiatong-lab914/obsidian-knowledge-mode) — DSH agent preset for a portable, AI-native knowledge system on Obsidian: anti-hoarding Layer 0, 80/20 distillation into Context/Claim, verifiable update loops, four read-only role agents, a source gate hook, and a zero-content starter template.
 - [alllllllllli/Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) — Complete DSH desktop config framework: 8+ MCP servers (computer-use, browser, memory, OCR, vision, history, markitdown, os-copilot), free model channels (CNB proxy, AMD Radeon Cloud), mobile remote via Tailscale, vision patches (GLM-4V-Flash → Ollama fallback), and a one-click installer (PowerShell + offline 120 MB SFX). MIT.
 - [JingMox/learner-preset](https://github.com/JingMox/learner-preset) — First-principles learning assistant preset for DeepSeek Harness: knowledge components with decaying mastery, an analogy lifecycle, and a prediction ledger.
+- [hackerFish/awesome-dsh-presets](https://github.com/hackerFish/awesome-dsh-presets) — Tested DeepSeek Harness presets & rules: official-derived + original combos, every preset passes structure and package-existence validation (Chinese-first).
 
 ## Harnesses & Runtimes
 
@@ -396,6 +397,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [PerryLink/dsh-mask](https://github.com/PerryLink/dsh-mask) — PII masking middleware for DeepSeek Harness: anonymize names, phones, emails, ID cards, bank cards, keys, and addresses to placeholders before they reach the model, restore them at the display layer, keep the restore table only in memory and a controlled storage domain, never log plaintext, and expose /mask and the mask_test tool.
 - [CanGeng/yolo-mode](https://github.com/CanGeng/yolo-mode) — Unattended full-access (yolo) window for DeepSeek Harness: human-only `/yolo` switch, lazy expiry with auto-revert, catastrophic-command tripwire guard, desktop/webhook/email notifications.
 - [yauntyour/DSH-Encrypt](https://github.com/yauntyour/DSH-Encrypt) — Credential-encryption plugin for DeepSeek Harness: password-gated AES-256-GCM + SHA3-256 full-pipeline encryption and verification, transient runtime decryption, memory-safe.
+- [hackerFish/dsh-lab](https://github.com/hackerFish/dsh-lab) — DSH lab: curated DeepSeek Harness plugins and a Chinese guide; every entry passes a real-machine four-gate test (install → smoke → security quick-check → compatibility pinning).
 
 ## Session & Memory Management
 
@@ -748,6 +750,8 @@ _Plugin marketplaces, install managers, indexes, and ecosystem tooling._
 - [XINGchi0130/dsh-base-plugin](https://github.com/XINGchi0130/dsh-base-plugin) — Base plugin for DeepSeek Harness (DSH): plugin market, MCP, skills, usage, sessions, mobile access — zero harness source changes.
 - [AJUbest/dsh-plugin-optimization](https://github.com/AJUbest/dsh-plugin-optimization) — A DSH plugin that distinguishes official built-in DSH plugins from user custom plugins on the external interface, and can collect and manage all your previously created custom plugins.
 - [DshMarketPlace/dshmarketplace](https://github.com/DshMarketPlace/dshmarketplace) — Bilingual directory of DeepSeek Harness (DSH) plugins — 1,004 listings, written detail pages, public API. Next.js on Cloudflare Workers.
+- [hackerFish/awesome-dsh-plugin](https://github.com/hackerFish/awesome-dsh-plugin) — A curated list of plugins for DeepSeek Harness (dsh).
+
 ## Visualization
 
 _Plugins that turn data / results into charts, diagrams, dashboards._
@@ -844,6 +848,7 @@ _Plugins that turn data / results into charts, diagrams, dashboards._
 - [QCYTSN/dsh-dafeiyu](https://github.com/QCYTSN/dsh-dafeiyu) — Desktop-native BigFish companion for DeepSeek Harness — real Agent status, always on top on Windows.
 - [zeroa234/dsh-comfyui](https://github.com/zeroa234/dsh-comfyui) — ComfyUI driver (AI-first contract mode): models see only contract slots, never workflow JSON. Text-to-image / image-to-image / text-to-video / image-to-video templates, dual preflight checks against hallucination, official/custom node liveness detection.
 - [Bob-Bo1/dsh-stock-watch](https://github.com/Bob-Bo1/dsh-stock-watch) — DeepSeek Harness (DSH) plugin for local A-share portfolio tracking: reads a local `holdings.json` and shows quotes and P&L in the sidebar.
+- [hackerFish/dsh-video-studio](https://github.com/hackerFish/dsh-video-studio) — Whale Video Studio: a DeepSeek Harness native video/motion-comic generation plugin — six-stage director pipeline, multi-vendor free-quota scheduling, four-layer prompt self-optimization.
 
 ## Slides / PPT
 
@@ -1781,6 +1786,8 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [SongYuhui14/crypto-evaluation-assistant](https://github.com/SongYuhui14/crypto-evaluation-assistant) — 商用密码应用安全性评估（密评）检测辅助技能：GB/T 39786 / GM/T 0115/0116 框架下的检测、符合率计算与报告生成工具链（3 个零依赖 Python 脚本），含金融/政务/能源行业垂直检查清单与备考学习模式，附三轮评测基线对比。
 - [allentnetus/dsh-job-hunting](https://github.com/allentnetus/dsh-job-hunting) — DeepSeek Harness job-hunting plugin and runtime skill for local job-intelligence workflows.
 - [lusblead/dsh-Kingdom](https://github.com/lusblead/dsh-Kingdom) — Standalone dsh plugin: initializes/connects a local Kingdom inside DSH sessions (Phase 1+2 FROZEN, Claim != Fact governance closed loop).
+- [hackerFish/awesome-dsh-skills](https://github.com/hackerFish/awesome-dsh-skills) — Tested DeepSeek Harness skill library: 15 original skills, every SKILL.md passes a format validator and a load smoke test — copy, drop in, done (Chinese-first, CI on Ubuntu + Windows).
+- [hackerFish/dsh-restart](https://github.com/hackerFish/dsh-restart) — Start, restart, and troubleshoot your local dsh web service: DSH skill (in-chat) + cross-platform safe launcher (works even when dsh is down), zero dependencies, bilingual docs.
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -82,6 +82,7 @@ _DSH 的核心组合机制：一个 **profile** 叠加各 bundle 的 patch 层�
 - [brunhildzhou/dsh-all-warmup](https://github.com/brunhildzhou/dsh-all-warmup) —— DeepSeek Harness 全局无感热身层插件：任何会话首轮自动热身，第二轮起恢复完整模式。
 - [jiatong-lab914/obsidian-knowledge-mode](https://github.com/jiatong-lab914/obsidian-knowledge-mode) —— Obsidian 可携带、AI-native 的知识系统 DSH agent preset：反收藏夹 Layer 0、二八提炼为 Context/Claim、可验证的更新环、四个只读角色代理、外部来源 Gate 钩子与零内容 starter 模板。
 - [JingMox/learner-preset](https://github.com/JingMox/learner-preset) —— 面向第一性原理学习的 DeepSeek Harness 智能体预设：知识组件带衰减掌握度、类比生命周期与预测账本。
+- [hackerFish/awesome-dsh-presets](https://github.com/hackerFish/awesome-dsh-presets) —— 实测可用的 DeepSeek Harness 预设与规则合集：官方派生 + 原创组合，每个预设通过结构与包存在性校验（中文优先）。
 
 ## Harness 与运行时
 
@@ -393,6 +394,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 - [PerryLink/dsh-mask](https://github.com/PerryLink/dsh-mask) —— DeepSeek Harness 的 PII 掩码中间件：在到达模型前把姓名、电话、邮箱、身份证、银行卡、密钥与地址匿名化为占位符，在展示层还原，还原表仅保存在内存与受控存储域中，绝不记录明文，并提供 /mask 命令与 mask_test 工具。
 - [CanGeng/yolo-mode](https://github.com/CanGeng/yolo-mode) —— DeepSeek Harness 的无人看管全权限（yolo）时间窗：人工专属 /yolo 开关、惰性过期自动回滚、灾难性命令红线报警，及桌面/webhook/邮件通知。
 - [yauntyour/DSH-Encrypt](https://github.com/yauntyour/DSH-Encrypt) —— DeepSeek Harness 凭据加密插件：通过设密码实现 AES-256-GCM+SHA3-256 全流程加密+校验，运行时临时解密，内存安全。
+- [hackerFish/dsh-lab](https://github.com/hackerFish/dsh-lab) —— DSH 实验室：每个条目都经真机四关测试（安装→冒烟→安全快检→兼容钉版）的插件实测精选与中文指南。
 
 ## 会话与记忆管理
 
@@ -741,6 +743,8 @@ _插件市场、安装管理器、索引与生态工具。_
 - [XINGchi0130/dsh-base-plugin](https://github.com/XINGchi0130/dsh-base-plugin) — DeepSeek Harness（DSH）基础插件：插件市场、MCP、Skills、用量、会话、移动端访问——零修改 harness 源码。
 - [AJUbest/dsh-plugin-optimization](https://github.com/AJUbest/dsh-plugin-optimization) —— 一款 DSH 插件，可在 Web 界面区分 DSH 自带插件与自定义插件，并能够收纳管理用户之前创建的全部自定义插件。
 - [DshMarketPlace/dshmarketplace](https://github.com/DshMarketPlace/dshmarketplace) —— DeepSeek Harness（DSH）插件双语目录站——收录 1,004 个插件，带图文详情页与公开 API，基于 Next.js 部署在 Cloudflare Workers。
+- [hackerFish/awesome-dsh-plugin](https://github.com/hackerFish/awesome-dsh-plugin) —— DeepSeek Harness 插件精选列表（curated list）。
+
 ## 可视化
 
 _把数据 / 结果变成图表、图形、看板的插件。_
@@ -836,6 +840,7 @@ _把数据 / 结果变成图表、图形、看板的插件。_
 - [QCYTSN/dsh-dafeiyu](https://github.com/QCYTSN/dsh-dafeiyu) —— 面向 DeepSeek Harness 的桌面原生大飞鱼伴侣——真实 Agent 状态，Windows 上总在最前。
 - [zeroa234/dsh-comfyui](https://github.com/zeroa234/dsh-comfyui) —— ComfyUI 驱动器（AI-first 合同制）：模型只见合同槽位、不见工作流 JSON。文生图/图生图/文生视频/图生视频模板，双重预检防幻觉，官方/自定义节点活体判定。
 - [Bob-Bo1/dsh-stock-watch](https://github.com/Bob-Bo1/dsh-stock-watch) —— 面向 DeepSeek Harness 的 A 股持仓追踪插件：读取本地 holdings.json，在侧边栏展示行情与盈亏。
+- [hackerFish/dsh-video-studio](https://github.com/hackerFish/dsh-video-studio) —— 鲸影 DSH Video Studio：DeepSeek Harness 原生视频/漫剧生成插件——六段导演流水线、多供应商免费额度调度、四层提示词自优化，质量优先省钱第二。
 
 ## 幻灯片 / PPT
 
@@ -1747,6 +1752,8 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [Wang-Lin-Chang/dsh-story](https://github.com/Wang-Lin-Chang/dsh-story) —— 面向 DeepSeek Harness 的长篇小说创作助手：故事账本 + 章节锚点 + 伏笔债审计 + 14 条叙事不变式硬规则（零误杀）。AI 审阅可能漏诺，账本不会。
 - [allentnetus/dsh-job-hunting](https://github.com/allentnetus/dsh-job-hunting) —— 面向本地求职情报工作流的 DeepSeek Harness 求职插件与运行时技能。
 - [lusblead/dsh-Kingdom](https://github.com/lusblead/dsh-Kingdom) —— 独立 dsh 插件：安装后在 DSH 会话中初始化/接入本地王国（Phase 1+2 FROZEN，Claim != Fact 治理闭环）。
+- [hackerFish/awesome-dsh-skills](https://github.com/hackerFish/awesome-dsh-skills) —— 实测可用的 DeepSeek Harness 技能库：15 个原创技能，每个 SKILL.md 都通过格式校验与加载冒烟，复制即用（中文优先，CI 双平台校验）。
+- [hackerFish/dsh-restart](https://github.com/hackerFish/dsh-restart) —— 启动/重启/排障本机 dsh Web 服务：DSH 技能（对话内触发）+ 跨平台安全启动器（dsh 宕机也能用），零依赖，含中英双语文档。
 
 ## 资源
 


### PR DESCRIPTION
新增 hackerFish 的 DSH 生态项目（全部已带 `#dsh` GitHub topic，符合收录要求）：

- **awesome-dsh-skills** → Skill：15 个原创技能，每个 SKILL.md 通过格式校验与加载冒烟，CI 双平台校验
- **dsh-restart** → Skill：启动/重启/排障 dsh Web 服务（DSH 技能 + 跨平台零依赖启动器）
- **awesome-dsh-plugin** → 插件市场与生态：DSH 插件精选列表
- **dsh-lab** → 安全与权限：插件实测实验室（安装→冒烟→安全快检→兼容钉版四关）
- **awesome-dsh-presets** → Profile 与 Patch 层：预设与规则合集（结构 + 包存在性校验）
- **dsh-video-studio** → 可视化：鲸影——DSH 原生视频/漫剧生成插件（六段导演流水线、多供应商免费额度调度）

中英 README 同步更新。