### PR TITLE
docs: add DSHPlugin.app to plugin ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ _Bridges DSH into chat platforms and messaging channels._
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 
 _Plugin marketplaces, install managers, indexes, and ecosystem tooling._
+- [DSHPlugin.app](https://dshplugin.app/) — Independent DeepSeek Harness plugin directory with source-backed capability summaries, install information, repository activity, and security signals.
 
 - [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) — GUI plugin marketplace.
 - [LX2000WASD/dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) — Web-based plugin manager.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -680,6 +680,7 @@ _把 DSH 桥接到各种聊天平台与消息通道。_
 ## 插件市场与生态
 
 _插件市场、安装管理器、索引与生态工具。_
+- [DSHPlugin.app](https://dshplugin.app/) —— 独立的 DeepSeek Harness 插件目录，提供基于源码的能力摘要、安装信息、仓库活跃度与安全信号。
 
 - [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) —— 插件市场 GUI。
 - [LX2000WASD/dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) —— 网页插件管理器。


### PR DESCRIPTION
## What are you adding?

- **Name:** DSHPlugin.app
- **Link:** https://dshplugin.app/
- **Category:** Plugin Marketplaces & Ecosystem
- **One-line description:** Independent DeepSeek Harness plugin directory with source-backed capability summaries, install information, repository activity, and security signals.

## Checklist

- [ ] The repo carries the `#dsh` GitHub topic — not applicable; this entry is a public web directory, not a repository.
- [x] I edited **both** `README.md` and `README.zh-CN.md`
- [x] Entry follows the requested link-and-description format
- [x] Description is factual and hype-free
- [x] The project is real, working, and publicly accessible

## Disclosure

I am affiliated with DSHPlugin.app. The directory is publicly accessible without sign-in and links entries to their source repositories.