### PR TITLE
fix(ci): make validate check report on non-README PRs

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -3,9 +3,10 @@ name: Validate PR
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'README.md'
-      - 'README.zh-CN.md'
+  # NOTE: intentionally no `paths:` filter. The `validate` check is a required
+  # status check on `main`; if the workflow is skipped for a PR that doesn't
+  # touch the README files, the check never reports and the PR is permanently
+  # unmergeable. Instead we always run and short-circuit inside the job.
 
 permissions:
   contents: read
@@ -29,9 +30,21 @@ jobs:
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           git fetch origin "pull/${PR_NUM}/head:pr-head"
-          echo "BASE_SHA=$(git merge-base origin/${{ github.base_ref }} pr-head)" >> "$GITHUB_ENV"
+          base_sha="$(git merge-base origin/${{ github.base_ref }} pr-head)"
+          echo "BASE_SHA=$base_sha" >> "$GITHUB_ENV"
+
+          # Does this PR touch the curated list files at all?
+          if git diff --name-only "$base_sha" pr-head \
+               | grep -qE '^(README\.md|README\.zh-CN\.md)$'; then
+            echo "IS_LIST_PR=true" >> "$GITHUB_ENV"
+          else
+            echo "IS_LIST_PR=false" >> "$GITHUB_ENV"
+            echo "This PR does not touch README.md / README.zh-CN.md."
+            echo "Skipping list-entry validation (nothing to check)."
+          fi
 
       - name: Check changed files scope
+        if: env.IS_LIST_PR == 'true'
         env:
           BASE_SHA: ${{ env.BASE_SHA }}
         run: |
@@ -48,6 +61,7 @@ jobs:
 
       - name: Validate new entries
         id: validate
+        if: env.IS_LIST_PR == 'true'
         env:
           BASE_SHA: ${{ env.BASE_SHA }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

`main` has a ruleset (`main protection`, active since 2026-08-17) requiring the **`validate`** status check:

```
required_status_checks: [ { context: "validate" } ]
required_approving_review_count: 0
```

But the workflow was filtered to only run on the list files:

```yaml
on:
  pull_request_target:
    paths:
      - 'README.md'
      - 'README.zh-CN.md'
```

So any PR that **doesn't** touch those two files never produces a `validate` result. The ruleset then waits forever on a check that will never report, and the PR becomes **permanently unmergeable**.

This is not hypothetical — #133 (docs, touched only `CONTRIBUTING.md`) hit exactly this and had to be merged with `--admin`. The same trap applies to any PR touching:

- `.github/workflows/**` (including this very fix)
- `CONTRIBUTING.md`, `LICENSE`
- `assets/**`

`--auto` doesn't help either: it just queues behind a check that never arrives.

## Fix

Keep the validation logic identical, but make the check **always report**:

1. **Drop the `paths:` filter** so the workflow runs for every PR.
2. **Classify inside the job** — `Fetch PR head` now sets `IS_LIST_PR` based on whether the diff touches `README.md` / `README.zh-CN.md`.
3. **Gate the two list-specific steps** on `if: env.IS_LIST_PR == 'true'`:
   - `Check changed files scope` (would otherwise hard-fail non-list PRs, since it rejects any file outside the two READMEs)
   - `Validate new entries`

Net effect:

| PR type | Before | After |
| --- | --- | --- |
| Touches README(s) | validated | validated, **unchanged** |
| Doesn't touch README(s) | check never reports → permanently blocked | `validate` passes, steps skipped |

## Verification

```
YAML parses OK
paths filter present? False
  step='Checkout base'                  if=(always)
  step='Fetch PR head'                  if=(always)
  step='Check changed files scope'      if=env.IS_LIST_PR == 'true'
  step='Validate new entries'           if=env.IS_LIST_PR == 'true'
  step='Comment findings'               if=always() && steps.validate.outputs.result == 'fail'
```

This PR is its own test case: it touches only `.github/workflows/`, so under the old config it would have been unmergeable. If `validate` reports green here, the fix works.

> Note: because the broken config is still what's running on `main`, this PR may itself need `--admin` to land — after that, non-list PRs merge normally.
