### PR TITLE
Add lanbaolu/dsh-wechat-bridge to Channel / IM Bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ _Bridges DSH into chat platforms and messaging channels._
 - [Gum97/dsh-telegram](https://github.com/Gum97/dsh-telegram) — Telegram channel for DeepSeek Harness — rich tables, images both ways, inline-keyboard questions, in-chat model switching.
 - [ringclaw/dsh-ringcentral](https://github.com/ringclaw/dsh-ringcentral) — Plugin for integrating RingCentral with DeepSeek Harness (dsh).
 - [xiaomengxinbb/dsh-qq-bridge](https://github.com/xiaomengxinbb/dsh-qq-bridge) — Two-way bridge connecting QQ (private + group chats) to DeepSeek Harness: each QQ conversation gets an isolated, persistent Agent session, with support for commands/approvals/multimedia/outbound files.
+- [lanbaolu/dsh-wechat-bridge](https://github.com/lanbaolu/dsh-wechat-bridge) — Personal WeChat bridge for DeepSeek Harness: scan QR to bind, then chat with your local DSH agent directly inside WeChat (text/image/voice/file, streamed replies, persisted sessions, Win/macOS/Linux).
 
 ## Plugin Marketplaces & Ecosystem
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -740,6 +740,7 @@ _把 DSH 桥接到各种聊天平台与消息通道。_
 - [Gum97/dsh-telegram](https://github.com/Gum97/dsh-telegram) —— DeepSeek Harness 的 Telegram 频道：富文本表格、双向图片、内联键盘提问、会话内模型切换。
 - [ringclaw/dsh-ringcentral](https://github.com/ringclaw/dsh-ringcentral) —— 将 RingCentral 接入 DeepSeek Harness (dsh) 的插件。
 - [xiaomengxinbb/dsh-qq-bridge](https://github.com/xiaomengxinbb/dsh-qq-bridge) —— 将 QQ（私聊+群聊）接入 DeepSeek Harness 的双向桥插件：每个 QQ 对话一个隔离持久 Agent 会话，支持命令/审批/多媒体/出站文件。
+- [lanbaolu/dsh-wechat-bridge](https://github.com/lanbaolu/dsh-wechat-bridge) —— 个人微信桥接插件：扫码绑定后直接在微信里与本机 DeepSeek Harness Agent 对话（文字/图片/语音/文件、流式回复、会话持久化、三端通用）。
 
 ## 插件市场与生态
 


### PR DESCRIPTION
## What

Add **[@lanbaolu/dsh-wechat-bridge](https://github.com/lanbaolu/dsh-wechat-bridge)** to the `Channel / IM Bridges` section (both `README.md` and `README.zh-CN.md`), a pure insertion of 2 lines.

## Why

A personal-WeChat bridge plugin for DeepSeek Harness:

- Scan QR code to bind, then chat with the **local DSH agent directly inside WeChat** (no extra app, no web page).
- Text / image / voice-to-text / file both ways; streamed replies batched to avoid spam.
- Per-account persisted DSH sessions — context survives host restarts (auto resume).
- Daemon lifecycle managed by DSH model tools + Web settings panel; Win / macOS / Linux.
- Repo carries `dsh`, `deepseek-harness`, `dsh-plugin`, `agent-preset`, `cordis-plugin` topics.
- Published on npm as `@lanbaolu/dsh-wechat-bridge`.

## Checklist

- [x] Repo tagged with `#dsh` topic
- [x] Both README.md and README.zh-CN.md updated in sync
- [x] Only new lines added, existing entries untouched