### PR TITLE
Add directwire/culmen (dsh-plugin-persona) — cross-runtime personality memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 
 - [reshuibuduo/TMCRA-Agent-Memory](https://github.com/reshuibuduo/TMCRA-Agent-Memory) — Technical-preview owner-local graph memory for DSH and Codex: recalls owner-global and current-project evidence before each turn, keeps USER and ASSISTANT records separate, and preserves project, session, actor, and source provenance.
+- [directwire/culmen](https://github.com/directwire/culmen) — Cross-runtime personality memory for dsh (dsh-plugin-persona): identity, memories, relationship stage, and diary stored in the portable persona/v1 format — the same persona directory works with Claude Code, OpenClaw, and Hermes.
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
 - [sjh9714/dsh-what-changed](https://github.com/sjh9714/dsh-what-changed) — Session-wide file change review in the session header. Lists every file the agent wrote this session with its hunks, counts refused writes separately from changes, and folds from a session projection rather than the on-disk log.
 - [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) — Bounded cross-session memory backed by SQLite.


### PR DESCRIPTION
@
Adds directwire/culmen to the **Session & Memory Management** section.

**dsh-plugin-persona** gives dsh cross-session memory + personality backed by the
persona/v1 format — a portable personality spec (identity, memories, relationship
stage, diary, append-only ledger). The **same persona directory** works across
Claude Code, OpenClaw, Hermes, and dsh through the shared persona-backend bridge,
so memory migrates with the user, not the tool.

Unlike dsh-private memory plugins, this is a cross-runtime format: data is
portable, not bound to DeepSeek Harness.

Tested end-to-end on dsh 0.1.0-rc.7 (Node 24): all three hooks verified
(`agent/pre-step` → retrieve inject, `session/event` → capture,
`agent/turn-stopping` → diary). Repo carries the `#dsh` GitHub topic.
@