### PR TITLE
Add bpc-oss/dsh-verification (verification gate for agent completion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,7 @@ _Code generation, refactoring, review, repo-level engineering plugins._
 
 _Reusable sub-agents / specialized agent packs runnable inside DSH._
 
+- [bpc-oss/dsh-verification](https://github.com/bpc-oss/dsh-verification) — Verification gate for agents: every acceptance criterion must be backed by server-stamped real tool evidence before the completion gate lets a goal through (advisory audit, enforce gate, durable permits).
 - [hewzhew/dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) — SillyTavern migration and next-generation agent role-play for DSH.  `⭐67`
 - [whiteguo233/dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) — Embeds OpenBiliClaw, a local personalized content-recommendation agent, as a fourth panel in DSH with 22 agent-bridge tools for reading recommendations and closed-loop learning.
 - [omdsh-dev/dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) — Lets the agent connect to databases and write SQL for you.


### PR DESCRIPTION
Add **bpc-oss/dsh-verification** to the Agents section.

**What it does**: a verification gate for agent completion — every acceptance criterion must be backed by server-stamped real tool evidence (not model self-reports) before the completion gate lets a goal through. Advisory mode audits (never blocks); enforce mode rejects unverified completions with a defect list. Repo carries the \dsh\ and \dsh-plugin\ topics; \dsh.bundle\ manifest declared (installable via \dsh plugin add\). Benchmarks + design docs in-repo.
