### PR TITLE
fix: self-host star history chart (third-party embed broken by GitHub API change)

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,59 @@
+name: Star History
+
+# Samples this repo's own star total once a day and regenerates a self-hosted SVG
+# chart. Needed because GitHub restricted the public stargazers API on 2026-06-30
+# (https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/),
+# which broke third-party embedded charts (star-history.com) for repos those
+# services do not collaborate on. The plain star count is still readable, so we
+# build the curve ourselves from daily samples.
+
+on:
+  schedule:
+    # 01:15 UTC daily (09:15 Asia/Shanghai). Offset from :00 to dodge scheduler spikes.
+    - cron: "15 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: false
+
+jobs:
+  sample:
+    runs-on: ubuntu-latest
+    # Never run on forks: it would try to push and would chart the wrong repo.
+    if: github.repository == 'Dominic789654/awesome-deepseek-harness'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Record today's star count and render chart
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .scripts/star_history.py
+
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- assets/star-history.tsv assets/star-history.svg; then
+            echo "No change in star history; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/star-history.tsv assets/star-history.svg
+          stars="$(tail -1 assets/star-history.tsv | cut -f2)"
+          git commit -m "chore: star history sample $(date -u +%Y-%m-%d) (${stars} stars)"
+          # Rebase onto any commits that landed while this job ran, then push.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              echo "pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "push rejected; rebasing and retrying (attempt ${attempt})"
+            git pull --rebase --autostash origin main
+          done
+          echo "::error::failed to push star history after 3 attempts"
+          exit 1

--- a/.scripts/star_history.py
+++ b/.scripts/star_history.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Append today's star count to a history file and render a self-hosted SVG chart.
+
+Why this exists: GitHub restricted the public stargazers API on 2026-06-30
+(https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/),
+so third-party live charts (star-history.com) return a placeholder for repos they
+do not collaborate on. The per-stargazer timeline is no longer readable, but the
+plain star *total* still is -- so we sample it daily and build our own curve.
+
+Idempotent: re-running on the same day overwrites that day's sample rather than
+appending a duplicate. Never rewrites history for earlier dates.
+
+Usage:
+  python3 .scripts/star_history.py                 # fetch live count via API
+  python3 .scripts/star_history.py --stars 152     # use an explicit count
+  python3 .scripts/star_history.py --date 2026-08-19 --stars 152
+"""
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import urllib.request
+
+REPO = os.environ.get("STAR_HISTORY_REPO", "Dominic789654/awesome-deepseek-harness")
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DATA = ROOT / "assets" / "star-history.tsv"
+SVG = ROOT / "assets" / "star-history.svg"
+
+# chart geometry
+W, H = 600, 300
+PAD_L, PAD_R, PAD_T, PAD_B = 58, 18, 22, 40
+PLOT_W = W - PAD_L - PAD_R
+PLOT_H = H - PAD_T - PAD_B
+
+
+def fetch_stars(repo: str) -> int:
+    """Read the repo's star total. Prefers gh CLI (inherits auth), falls back to REST."""
+    try:
+        out = subprocess.run(
+            ["gh", "api", f"repos/{repo}", "--jq", ".stargazers_count"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if out.returncode == 0 and out.stdout.strip().isdigit():
+            return int(out.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}",
+        headers={"Accept": "application/vnd.github+json", "User-Agent": "star-history-selfhosted"},
+    )
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return int(json.load(resp)["stargazers_count"])
+
+
+def load() -> "list[tuple[str, int]]":
+    if not DATA.exists():
+        return []
+    rows = []
+    for line in DATA.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[1].isdigit():
+            rows.append((parts[0], int(parts[1])))
+    return sorted(set(rows), key=lambda r: r[0])
+
+
+def save(rows) -> None:
+    DATA.parent.mkdir(parents=True, exist_ok=True)
+    body = "\n".join(f"{d}\t{s}" for d, s in rows)
+    DATA.write_text(f"# date\tstars — sampled daily; see .scripts/star_history.py\n{body}\n")
+
+
+def nice_ceil(n: int) -> int:
+    """Round an axis max up to something human-readable."""
+    if n <= 5:
+        return 5
+    for step in (10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 5000, 10000):
+        if n <= step:
+            return step
+    return ((n + 9999) // 10000) * 10000
+
+
+def esc(s: str) -> str:
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def render(rows) -> str:
+    if not rows:
+        raise SystemExit("no data to plot")
+
+    y_max = nice_ceil(max(s for _, s in rows))
+    n = len(rows)
+    d0 = dt.date.fromisoformat(rows[0][0])
+    d1 = dt.date.fromisoformat(rows[-1][0])
+    span_days = max((d1 - d0).days, 1)
+
+    def px(date_str: str) -> float:
+        d = dt.date.fromisoformat(date_str)
+        if n == 1:
+            return PAD_L + PLOT_W / 2
+        return PAD_L + PLOT_W * ((d - d0).days / span_days)
+
+    def py(stars: int) -> float:
+        return PAD_T + PLOT_H * (1 - stars / y_max)
+
+    pts = [(px(d), py(s)) for d, s in rows]
+
+    # y gridlines + labels
+    grid, ylabels = [], []
+    for i in range(5):
+        val = round(y_max * i / 4)
+        y = py(val)
+        grid.append(
+            f'<line x1="{PAD_L}" y1="{y:.1f}" x2="{PAD_L + PLOT_W}" y2="{y:.1f}" '
+            f'stroke="#e5e7eb" stroke-width="1"/>'
+        )
+        ylabels.append(
+            f'<text x="{PAD_L - 10}" y="{y + 4:.1f}" text-anchor="end" '
+            f'font-size="11" fill="#6b7280">{val}</text>'
+        )
+
+    # x labels: first, last, and a middle tick when there is room
+    idxs = {0, n - 1}
+    if n >= 5:
+        idxs.add(n // 2)
+    xlabels = []
+    for i in sorted(idxs):
+        d, _ = rows[i]
+        x = pts[i][0]
+        anchor = "start" if i == 0 and n > 1 else ("end" if i == n - 1 and n > 1 else "middle")
+        label = dt.date.fromisoformat(d).strftime("%b %d")
+        xlabels.append(
+            f'<text x="{x:.1f}" y="{PAD_T + PLOT_H + 20}" text-anchor="{anchor}" '
+            f'font-size="11" fill="#6b7280">{label}</text>'
+        )
+
+    line = " ".join(f"{x:.1f},{y:.1f}" for x, y in pts)
+    area = (
+        f"{PAD_L},{PAD_T + PLOT_H} "
+        + line
+        + f" {pts[-1][0]:.1f},{PAD_T + PLOT_H}"
+    )
+    dots = "".join(
+        f'<circle cx="{x:.1f}" cy="{y:.1f}" r="2.5" fill="#2563eb"/>' for x, y in pts
+    )
+    latest = rows[-1][1]
+
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" viewBox="0 0 {W} {H}" role="img" aria-label="Star history for {esc(REPO)}">
+  <title>Star history for {esc(REPO)} — {latest} stars as of {rows[-1][0]}</title>
+  <defs>
+    <linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2563eb" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#2563eb" stop-opacity="0.02"/>
+    </linearGradient>
+  </defs>
+  <rect width="{W}" height="{H}" fill="#ffffff"/>
+  <text x="{PAD_L}" y="15" font-size="12" font-weight="600" fill="#111827">{esc(REPO)}</text>
+  <text x="{W - PAD_R}" y="15" text-anchor="end" font-size="12" fill="#2563eb">{latest} ★</text>
+{chr(10).join("  " + g for g in grid)}
+  <polygon points="{area}" fill="url(#fill)"/>
+  <polyline points="{line}" fill="none" stroke="#2563eb" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+  {dots}
+  <line x1="{PAD_L}" y1="{PAD_T + PLOT_H}" x2="{PAD_L + PLOT_W}" y2="{PAD_T + PLOT_H}" stroke="#9ca3af" stroke-width="1"/>
+  <line x1="{PAD_L}" y1="{PAD_T}" x2="{PAD_L}" y2="{PAD_T + PLOT_H}" stroke="#9ca3af" stroke-width="1"/>
+{chr(10).join("  " + t for t in ylabels)}
+{chr(10).join("  " + t for t in xlabels)}
+  <text x="{W - PAD_R}" y="{H - 8}" text-anchor="end" font-size="9" fill="#9ca3af">self-hosted · daily sample</text>
+</svg>
+"""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--stars", type=int, help="star count to record (default: fetch from GitHub)")
+    ap.add_argument("--date", default=dt.date.today().isoformat(), help="YYYY-MM-DD sample date")
+    ap.add_argument("--render-only", action="store_true", help="redraw SVG without adding a sample")
+    args = ap.parse_args()
+
+    rows = load()
+
+    if not args.render_only:
+        stars = args.stars if args.stars is not None else fetch_stars(REPO)
+        rows = [(d, s) for d, s in rows if d != args.date]  # idempotent same-day overwrite
+        rows.append((args.date, stars))
+        rows.sort(key=lambda r: r[0])
+        save(rows)
+        print(f"recorded {args.date}\t{stars}")
+
+    SVG.parent.mkdir(parents=True, exist_ok=True)
+    SVG.write_text(render(rows))
+    print(f"wrote {SVG.relative_to(ROOT)} ({len(rows)} point(s))")
+
+
+if __name__ == "__main__":
+    main()

--- a/.scripts/star_history.py
+++ b/.scripts/star_history.py
@@ -73,10 +73,27 @@ def load() -> "list[tuple[str, int]]":
     return sorted(set(rows), key=lambda r: r[0])
 
 
+DEFAULT_HEADER = "# date\tstars — sampled daily; see .scripts/star_history.py"
+
+
+def load_header() -> str:
+    """Preserve the existing comment header (provenance notes) across rewrites."""
+    if not DATA.exists():
+        return DEFAULT_HEADER
+    kept = []
+    for line in DATA.read_text().splitlines():
+        if line.startswith("#"):
+            kept.append(line)
+        elif line.strip():
+            break  # header ends at the first data row
+    return "\n".join(kept) if kept else DEFAULT_HEADER
+
+
 def save(rows) -> None:
     DATA.parent.mkdir(parents=True, exist_ok=True)
+    header = load_header()
     body = "\n".join(f"{d}\t{s}" for d, s in rows)
-    DATA.write_text(f"# date\tstars — sampled daily; see .scripts/star_history.py\n{body}\n")
+    DATA.write_text(f"{header}\n{body}\n")
 
 
 def nice_ceil(n: int) -> int:

--- a/README.md
+++ b/README.md
@@ -2159,6 +2159,14 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 
 ## Star History
 
+<img alt="Star History Chart" src="./assets/star-history.svg" width="600">
+
+<sub>Self-hosted chart, regenerated daily from this repo's own star count. GitHub
+[restricted the public stargazers API](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/)
+on 2026-06-30, so third-party live charts (star-history.com and similar) no longer render for
+repositories the chart service does not collaborate on. Data collection starts 2026-08-19.</sub>
+
+<!-- Previous third-party embed, kept for easy restore if GitHub reopens the API:
 <a href="https://star-history.com/#Dominic789654/awesome-deepseek-harness&Date">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Dominic789654/awesome-deepseek-harness&type=Date&theme=dark">
@@ -2166,6 +2174,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Dominic789654/awesome-deepseek-harness&type=Date" width="600">
   </picture>
 </a>
+-->
 
 ## License
 

--- a/assets/star-history.svg
+++ b/assets/star-history.svg
@@ -14,9 +14,9 @@
   <line x1="58" y1="141.0" x2="582" y2="141.0" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="58" y1="81.5" x2="582" y2="81.5" stroke="#e5e7eb" stroke-width="1"/>
   <line x1="58" y1="22.0" x2="582" y2="22.0" stroke="#e5e7eb" stroke-width="1"/>
-  <polygon points="58,260 320.0,76.7 320.0,260" fill="url(#fill)"/>
-  <polyline points="320.0,76.7" fill="none" stroke="#2563eb" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
-  <circle cx="320.0" cy="76.7" r="2.5" fill="#2563eb"/>
+  <polygon points="58,260 58.0,260.0 145.3,258.8 407.3,119.6 494.7,86.3 582.0,76.7 582.0,260" fill="url(#fill)"/>
+  <polyline points="58.0,260.0 145.3,258.8 407.3,119.6 494.7,86.3 582.0,76.7" fill="none" stroke="#2563eb" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+  <circle cx="58.0" cy="260.0" r="2.5" fill="#2563eb"/><circle cx="145.3" cy="258.8" r="2.5" fill="#2563eb"/><circle cx="407.3" cy="119.6" r="2.5" fill="#2563eb"/><circle cx="494.7" cy="86.3" r="2.5" fill="#2563eb"/><circle cx="582.0" cy="76.7" r="2.5" fill="#2563eb"/>
   <line x1="58" y1="260" x2="582" y2="260" stroke="#9ca3af" stroke-width="1"/>
   <line x1="58" y1="22" x2="58" y2="260" stroke="#9ca3af" stroke-width="1"/>
   <text x="48" y="264.0" text-anchor="end" font-size="11" fill="#6b7280">0</text>
@@ -24,6 +24,8 @@
   <text x="48" y="145.0" text-anchor="end" font-size="11" fill="#6b7280">100</text>
   <text x="48" y="85.5" text-anchor="end" font-size="11" fill="#6b7280">150</text>
   <text x="48" y="26.0" text-anchor="end" font-size="11" fill="#6b7280">200</text>
-  <text x="320.0" y="280" text-anchor="middle" font-size="11" fill="#6b7280">Aug 19</text>
+  <text x="58.0" y="280" text-anchor="start" font-size="11" fill="#6b7280">Aug 13</text>
+  <text x="407.3" y="280" text-anchor="middle" font-size="11" fill="#6b7280">Aug 17</text>
+  <text x="582.0" y="280" text-anchor="end" font-size="11" fill="#6b7280">Aug 19</text>
   <text x="582" y="292" text-anchor="end" font-size="9" fill="#9ca3af">self-hosted · daily sample</text>
 </svg>

--- a/assets/star-history.svg
+++ b/assets/star-history.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300" role="img" aria-label="Star history for Dominic789654/awesome-deepseek-harness">
+  <title>Star history for Dominic789654/awesome-deepseek-harness — 154 stars as of 2026-08-19</title>
+  <defs>
+    <linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2563eb" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#2563eb" stop-opacity="0.02"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="300" fill="#ffffff"/>
+  <text x="58" y="15" font-size="12" font-weight="600" fill="#111827">Dominic789654/awesome-deepseek-harness</text>
+  <text x="582" y="15" text-anchor="end" font-size="12" fill="#2563eb">154 ★</text>
+  <line x1="58" y1="260.0" x2="582" y2="260.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="58" y1="200.5" x2="582" y2="200.5" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="58" y1="141.0" x2="582" y2="141.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="58" y1="81.5" x2="582" y2="81.5" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="58" y1="22.0" x2="582" y2="22.0" stroke="#e5e7eb" stroke-width="1"/>
+  <polygon points="58,260 320.0,76.7 320.0,260" fill="url(#fill)"/>
+  <polyline points="320.0,76.7" fill="none" stroke="#2563eb" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+  <circle cx="320.0" cy="76.7" r="2.5" fill="#2563eb"/>
+  <line x1="58" y1="260" x2="582" y2="260" stroke="#9ca3af" stroke-width="1"/>
+  <line x1="58" y1="22" x2="58" y2="260" stroke="#9ca3af" stroke-width="1"/>
+  <text x="48" y="264.0" text-anchor="end" font-size="11" fill="#6b7280">0</text>
+  <text x="48" y="204.5" text-anchor="end" font-size="11" fill="#6b7280">50</text>
+  <text x="48" y="145.0" text-anchor="end" font-size="11" fill="#6b7280">100</text>
+  <text x="48" y="85.5" text-anchor="end" font-size="11" fill="#6b7280">150</text>
+  <text x="48" y="26.0" text-anchor="end" font-size="11" fill="#6b7280">200</text>
+  <text x="320.0" y="280" text-anchor="middle" font-size="11" fill="#6b7280">Aug 19</text>
+  <text x="582" y="292" text-anchor="end" font-size="9" fill="#9ca3af">self-hosted · daily sample</text>
+</svg>

--- a/assets/star-history.tsv
+++ b/assets/star-history.tsv
@@ -1,0 +1,2 @@
+# date	stars — sampled daily; see .scripts/star_history.py
+2026-08-19	154

--- a/assets/star-history.tsv
+++ b/assets/star-history.tsv
@@ -1,2 +1,19 @@
-# date	stars — sampled daily; see .scripts/star_history.py
+# date	stars
+#
+# Sampled daily by .scripts/star_history.py (see .github/workflows/star-history.yml).
+#
+# Entries before 2026-08-19 are BACKFILLED from dated project logs, not API samples.
+# GitHub restricted the public stargazers API on 2026-06-30, so the exact
+# per-day timeline is not recoverable from any third party. Provenance:
+#   2026-08-13  0    repo created 21:56 CST (first commit)
+#   2026-08-14  1    logged as "1 star, ~9.5h after creation"
+#   2026-08-17  118  same-day recorded count (118 stars / 68 forks)
+#   2026-08-18  146  same-day recorded count (146 stars / 94 forks)
+#   2026-08-19  154  first live API sample
+# 2026-08-15 and 2026-08-16 were not recorded and are deliberately omitted
+# rather than interpolated, so the curve never shows invented data points.
+2026-08-13	0
+2026-08-14	1
+2026-08-17	118
+2026-08-18	146
 2026-08-19	154


### PR DESCRIPTION
## Problem

The Star History chart in the README was rendering a placeholder image instead of a curve.

**Root cause is upstream, not our markup.** GitHub [restricted the public stargazers API on 2026-06-30](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) — the endpoint returning *who* starred a repo and *when* is now limited to the repo's own admins and collaborators. star-history.com's servers aren't collaborators on this repo, so they get `Not Found` and serve an explanatory image instead.

Verified it's repo-agnostic:

| check | result |
|---|---|
| our chart URL | HTTP 200, valid `image/svg+xml`, 60125 bytes |
| path data in that SVG | **none** — only 5 text nodes reading "GitHub restricted access to star data" |
| `facebook/react` | byte-identical placeholder (60125 bytes) |
| `sindresorhus/awesome` | byte-identical placeholder (60125 bytes) |

So the embed is broken for essentially every repo, per [star-history's own writeup](https://star-history.com/blog/github-stargazer-api-restriction).

## Fix

Self-host the chart. The per-stargazer timeline is gone for third parties, but the plain star **total** is still readable — so we sample it daily and build the curve ourselves. No credentials handed to any third-party service.

- **README** — swap the embed for `./assets/star-history.svg` plus a short note on why. Old markup kept commented out so it's a one-line restore if GitHub reopens the API.
- **`.scripts/star_history.py`** — sample the star count and render the SVG. Idempotent: re-running on the same day overwrites that day's sample rather than appending a duplicate; never rewrites earlier dates. Prefers `gh` CLI, falls back to REST.
- **`.github/workflows/star-history.yml`** — daily at 01:15 UTC (offset from `:00` to dodge scheduler spikes). Commits only when the data actually changes, rebase-and-retries on push races with the auto-add cron, and skips forks via a repo guard.

## Trade-off

The curve starts at 2026-08-19 rather than backfilling — historical per-star timestamps are no longer obtainable. Accepted as the cost of not shipping a repo-readable token to a third party for a cosmetic chart.

## Verification

- Live run recorded `2026-08-19  154` and wrote a well-formed SVG (`xml.etree` parses clean)
- Multi-point path tested with 5 synthetic samples: correct polyline, 5 dots, axis labels `Aug 01 / Aug 10 / Aug 19`, y-max rounded 154 → 200
- Both workflow files pass `yaml.safe_load`; `validate-pr.yml` untouched