### PR TITLE
Add dsh-plugin-compat-checker (插件兼容性测试器) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1669,6 +1669,8 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [nanjingya/agent-diagram](https://github.com/nanjingya/agent-diagram) — Stop shipping Mermaid boxes. Agent skill for editorial HTML/SVG technical diagrams — DeepSeek Harness, Claude Code, Cursor.
 - [PHoenixs57/deepseek-aix](https://github.com/PHoenixs57/deepseek-aix) — Q-Q: a conversational AI research assistant for academic literature. Multi-source search (PubMed, arXiv, Semantic Scholar, Crossref), paper-card deduplication, and a folder-based favorites system — built on DeepSeek Harness.
 
+- [SongYuhui14/dsh-plugin-compat-checker](https://github.com/SongYuhui14/dsh-plugin-compat-checker) — DSH plugin: pre-install compatibility testing — predict whether a new plugin will conflict with or crash existing plugins (slot/prompt-section/dependency/version clashes). 插件兼容性测试器。
+
 ## Resources
 
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) — Official source repo.  `⭐38238`


### PR DESCRIPTION
Add [dsh-plugin-compat-checker](https://github.com/SongYuhui14/dsh-plugin-compat-checker) to the list.

A DSH plugin that pre-tests whether a new plugin will conflict with or crash existing plugins (slot collisions, prompt-section collisions, dependency conflicts, version mismatches). Repo carries the #dsh topic.