### PR TITLE
Add SandBase Harness runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,8 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [WODE25500/dsh-lan-share](https://github.com/WODE25500/dsh-lan-share) — DSH LAN file share: share the workspace over the local network — phones/tablets/other computers browse, download and upload files via browser, no DSH login. Token gate, path boundary, read-only mode, rate limit. Zero-dependency (node:http).
 - [yugasun/dsh-plugins](https://github.com/yugasun/dsh-plugins) — Personal plugin collection for DeepSeek Harness (dsh-plugin).
 
+- [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) — Local-first agent runtime integrated with DSH through an installable `managed-agents` plugin and six-tool MCP bridge; persistent sessions, resumable SSE, audit/replay, permissions, credentials, and local/Docker/Kubernetes/self-hosted-worker sandboxes.
+
 ## Security & Permissions
 
 _Permission rules, approval review, security audits, and policy-check plugins._

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -448,6 +448,8 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [WODE25500/dsh-lan-share](https://github.com/WODE25500/dsh-lan-share) —— DSH 局域网文件共享：把工作区共享到局域网 —— 手机/平板/其他电脑用浏览器浏览、下载、上传文件，无需 DSH 登录。Token 鉴权、路径边界、只读模式、限速。零依赖（node:http）。
 - [yugasun/dsh-plugins](https://github.com/yugasun/dsh-plugins) —— DeepSeek Harness 个人插件合集（dsh-plugin）。
 
+- [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) —— 通过可安装的 `managed-agents` 插件与六工具 MCP Bridge 接入 DSH 的 local-first Agent 运行时：提供持久会话、可恢复 SSE、审计/回放、权限、凭据，以及本地/Docker/Kubernetes/自托管 Worker 沙箱。
+
 ## 安全与权限
 
 _权限规则、审批复核、安全审计与调用前 policy-check 插件。_


### PR DESCRIPTION
## Summary

Adds SandBase Harness to **Harnesses & Runtimes** in both English and Chinese lists.

The entry focuses on its concrete DSH integration and runtime boundary:
- installable `managed-agents` DSH plugin
- six-tool MCP bridge for agents, sessions, streamed turns, artifacts, and cancellation
- persistent sessions and resumable SSE
- audit/replay, permissions, and credential handling
- local, Docker, Kubernetes, and self-hosted-worker sandboxes

## Validation

- Repository carries both `dsh` and `dsh-plugin` topics.
- Canonical repository is public and Apache-2.0 licensed.
- Diff is insert-only: one complete entry in each README, with no existing lines modified.
- `git diff --check` passes.

## Disclosure

I am affiliated with SandBase AI. The description is factual and based on the public v0.3.4 source and documentation. AI assistance was used to draft and verify the bilingual entry.