### PR TITLE
Add dsh-code-vetter (AI 代码安全审查器) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1669,6 +1669,8 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [nanjingya/agent-diagram](https://github.com/nanjingya/agent-diagram) — Stop shipping Mermaid boxes. Agent skill for editorial HTML/SVG technical diagrams — DeepSeek Harness, Claude Code, Cursor.
 - [PHoenixs57/deepseek-aix](https://github.com/PHoenixs57/deepseek-aix) — Q-Q: a conversational AI research assistant for academic literature. Multi-source search (PubMed, arXiv, Semantic Scholar, Crossref), paper-card deduplication, and a folder-based favorites system — built on DeepSeek Harness.
 
+- [SongYuhui14/dsh-code-vetter](https://github.com/SongYuhui14/dsh-code-vetter) — DSH plugin: AI code security reviewer — scan code for SQL/command injection, hardcoded secrets, dangerous functions, weak crypto, auth bypass (OWASP/CWE-aligned). AI 代码安全审查器。
+
 ## Resources
 
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) — Official source repo.  `⭐38238`


### PR DESCRIPTION
Add [dsh-code-vetter](https://github.com/SongYuhui14/dsh-code-vetter) to the list.

A DSH plugin that reviews AI-generated code security: SQL/command injection, hardcoded secrets, dangerous functions, weak crypto, auth bypass, XSS (OWASP/CWE-aligned, 11 rules). Repo carries the #dsh topic.