### PR TITLE
Add dsh-publisher (技能/插件一键发布助手) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1669,6 +1669,8 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [nanjingya/agent-diagram](https://github.com/nanjingya/agent-diagram) — Stop shipping Mermaid boxes. Agent skill for editorial HTML/SVG technical diagrams — DeepSeek Harness, Claude Code, Cursor.
 - [PHoenixs57/deepseek-aix](https://github.com/PHoenixs57/deepseek-aix) — Q-Q: a conversational AI research assistant for academic literature. Multi-source search (PubMed, arXiv, Semantic Scholar, Crossref), paper-card deduplication, and a folder-based favorites system — built on DeepSeek Harness.
 
+- [SongYuhui14/dsh-publisher](https://github.com/SongYuhui14/dsh-publisher) — DSH plugin: one-click publish planner for skills/plugins — validate project completeness, generate repo description, awesome-list entry, and PR commands. 技能/插件一键发布助手。
+
 ## Resources
 
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) — Official source repo.  `⭐38238`


### PR DESCRIPTION
Add [dsh-publisher](https://github.com/SongYuhui14/dsh-publisher) to the list.

A DSH plugin that generates one-click publish plans for skills/plugins: completeness validation, repo description, awesome-list entry, and PR commands. Repo carries the #dsh topic.