### PR TITLE
Add DSH plugin suite (7 repos): crash-surviving jobs, anchors, sandboxes, scheduling, multi-agent mesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,8 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [SiriLee/dsh-approval-hotkeys](https://github.com/SiriLee/dsh-approval-hotkeys) — DeepSeek Harness plugin: approval-panel hotkeys — Enter approves once, Esc rejects, Esc pauses a running agent.
 - [Eligahyu/dsh-sentinel-scanner](https://github.com/Eligahyu/dsh-sentinel-scanner) — X-ray for DeepSeek Harness plugins: security checkup and health check. Zero-dependency, read-only static scan — code execution, credentials, exfiltration, obfuscation, install scripts, bundle manifest — 0-100 risk score. DSH tool plugin + standalone CLI.
 
+- [Wang-Lin-Chang/dsh-cross-platform](https://github.com/Wang-Lin-Chang/dsh-cross-platform) — Linux backend for the dsh-witness and dsh-anchor plugins: chattr + bubblewrap sandbox recipes and process-identity utilities.
+- [Wang-Lin-Chang/dsh-macos](https://github.com/Wang-Lin-Chang/dsh-macos) — macOS backend for the dsh-witness and dsh-anchor plugins: uchg immutable flags plus a sandbox-exec deny view.
 ## Session & Memory Management
 
 _Cross-session memory, checkpoints, pinning, and session navigation plugins._
@@ -695,6 +697,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [Asher-2000/dsh-memory-connect](https://github.com/Asher-2000/dsh-memory-connect) — Cross-session memory plugin for DSH — auto-extraction, semantic recall, scheduled maintenance, LLM-powered consolidation.
 - [Li-canghai/dsh-archived-conversation](https://github.com/Li-canghai/dsh-archived-conversation) — Conversation-archiving plugin for DeepSeek Harness (dsh-plugin).
 
+- [Wang-Lin-Chang/dsh-anchor](https://github.com/Wang-Lin-Chang/dsh-anchor) — Long-running session supervision: pre-committed intent and immediate environment reconciliation for every high-entropy tool action.
 ## Cost & Usage Tracking
 
 _Token usage, cost dashboards, and budget-alert plugins._
@@ -1470,6 +1473,10 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [NelsonLongxiang/dsh-open-a2a-net](https://github.com/NelsonLongxiang/dsh-open-a2a-net) — Open A2A network plugin for DeepSeek Harness: signed agent cards, decentralized peer/zone discovery, direct routing model tools, and joinable session nodes in the web sidebar.
 - [oppnc/dsh-kernel-mesh](https://github.com/oppnc/dsh-kernel-mesh) — Harness-kernel mesh for DeepSeek Harness: kimi/grok/codex/minimax model routes (L1), distilled subagent recipes (L2) and kernel_run/kernel_status/kernel_switch tools.
 
+- [Wang-Lin-Chang/dsh-witness](https://github.com/Wang-Lin-Chang/dsh-witness) — Crash-surviving background jobs for DeepSeek Harness: filesystem as the source of truth, cross-restart adoption, autopsy reports, and sandboxed execution.
+- [Wang-Lin-Chang/schedule-core](https://github.com/Wang-Lin-Chang/schedule-core) — Persistent scheduler core: SQLite archive, lease-claim coordination, wall-clock discipline, zero framework dependencies.
+- [Wang-Lin-Chang/dsh-schedule](https://github.com/Wang-Lin-Chang/dsh-schedule) — Persistent scheduler plugin for DeepSeek Harness: reminders and scheduled jobs that survive session restarts.
+- [Wang-Lin-Chang/dsh-megamesh](https://github.com/Wang-Lin-Chang/dsh-megamesh) — Multi-agent architecture: files as messages, adoption over cascading failure, term leases, invariants over trust.
 ## UI / Clients
 
 - [Choi-Peng/dsh-footer-order](https://github.com/Choi-Peng/dsh-footer-order) — DSH Web plugin that fixes multiple plugin entries crowding into one line in the sidebar footer (`sidebar.footer.action` slot) and lets you configure their stacking order.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -527,6 +527,8 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 - [SiriLee/dsh-approval-hotkeys](https://github.com/SiriLee/dsh-approval-hotkeys) —— DeepSeek Harness 插件：审批面板快捷键 —— Enter 单次批准，Esc 拒绝，Esc 暂停运行中的 agent。
 - [Eligahyu/dsh-sentinel-scanner](https://github.com/Eligahyu/dsh-sentinel-scanner) —— 🛡️ 给 DeepSeek Harness 插件拍 X 光 —— 插件安全体检与健康检查。零依赖只读静态扫描：代码执行/凭据/外传/混淆/安装脚本/bundle 清单，0-100 风险分。DSH tool 插件 + 独立 CLI。
 
+- [Wang-Lin-Chang/dsh-cross-platform](https://github.com/Wang-Lin-Chang/dsh-cross-platform) —— dsh-witness / dsh-anchor 的 Linux 后端：chattr + bubblewrap 沙箱配方与进程身份工具。
+- [Wang-Lin-Chang/dsh-macos](https://github.com/Wang-Lin-Chang/dsh-macos) —— dsh-witness / dsh-anchor 的 macOS 后端：uchg 不可变位 + sandbox-exec deny 视图。
 ## 会话与记忆管理
 
 _跨会话记忆、checkpoint、会话置顶与导航插件。_
@@ -688,6 +690,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [Asher-2000/dsh-memory-connect](https://github.com/Asher-2000/dsh-memory-connect) —— DSH 跨会话记忆插件 —— 自动抽取、语义召回、定时维护、LLM 驱动的记忆整合。
 - [Li-canghai/dsh-archived-conversation](https://github.com/Li-canghai/dsh-archived-conversation) —— DeepSeek Harness 会话归档插件（dsh-plugin）。
 
+- [Wang-Lin-Chang/dsh-anchor](https://github.com/Wang-Lin-Chang/dsh-anchor) —— 长程会话监督：每个高熵工具动作的预承诺意图与即时环境对账。
 ## 成本与用量统计
 
 _token 用量、成本看板与预算告警插件。_
@@ -1451,6 +1454,10 @@ _多步 / 多 agent 调度器与输出聚合器。_
 - [NelsonLongxiang/dsh-open-a2a-net](https://github.com/NelsonLongxiang/dsh-open-a2a-net) —— DeepSeek Harness 的开放 A2A 网络插件：签名 agent card、去中心化的 peer/zone 发现、直连路由模型工具，以及 Web 侧边栏中可加入的会话节点。
 - [oppnc/dsh-kernel-mesh](https://github.com/oppnc/dsh-kernel-mesh) —— DeepSeek Harness 的 Harness-kernel mesh：kimi/grok/codex/minimax 模型路由（L1）、精炼的 subagent 配方（L2）以及 kernel_run/kernel_status/kernel_switch 工具。
 
+- [Wang-Lin-Chang/dsh-witness](https://github.com/Wang-Lin-Chang/dsh-witness) —— DeepSeek Harness 崩溃存活后台任务：文件系统即真相源、跨重启收养、尸检报告、沙箱执行。
+- [Wang-Lin-Chang/schedule-core](https://github.com/Wang-Lin-Chang/schedule-core) —— 持久调度核心：SQLite 档案馆、租约认领协调、墙钟纪律、零框架依赖。
+- [Wang-Lin-Chang/dsh-schedule](https://github.com/Wang-Lin-Chang/dsh-schedule) —— DeepSeek Harness 持久调度插件：跨会话存活的提醒与定时任务。
+- [Wang-Lin-Chang/dsh-megamesh](https://github.com/Wang-Lin-Chang/dsh-megamesh) —— 多智能体架构：文件即消息、收养代替陪葬、任期代替单点、军法代替信任。
 ## UI / 客户端
 
 _DSH 的桌面、网页、终端或编辑器前端。_


### PR DESCRIPTION
Add the DSH plugin suite entries discussed in [#92](https://github.com/Dominic789654/awesome-deepseek-harness/issues/92).

**Seven repos, all Apache-2.0, all carrying the `dsh` topic:**
- dsh-witness — crash-surviving background jobs
- dsh-anchor — session supervision with environment reconciliation
- dsh-cross-platform — Linux sandbox backend
- dsh-macos — macOS sandbox backend
- schedule-core — persistent scheduler core
- dsh-schedule — persistent scheduler plugin
- dsh-megamesh — multi-agent architecture

**Two framework-agnostic specs (asmfs-spec, autopsy-spec) are intentionally not included**, following the maintainer's suggestion in the issue thread — they deliberately aren't DSH-specific. We'll add a concrete DSH-integration note to their READMEs before proposing them separately.

Descriptions are factual and hype-free per the list format. Entries were placed in Security & Permissions / Session & Memory Management / Orchestrators & Aggregators.