### PR TITLE
新增 dsh-multiple-chat-panels 到 UI/客户端（Add dsh-multiple-chat-panels to UI/Clients）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,7 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [oppnc/dsh-kernel-mesh](https://github.com/oppnc/dsh-kernel-mesh) — Harness-kernel mesh for DeepSeek Harness: kimi/grok/codex/minimax model routes (L1), distilled subagent recipes (L2) and kernel_run/kernel_status/kernel_switch tools.
 
 ## UI / Clients
+- [WilliamShi666/dsh-multiple-chat-panels](https://github.com/WilliamShi666/dsh-multiple-chat-panels) — Multiple chat panels for DeepSeek Harness: view and interact with several Agents side by side.
 
 - [Choi-Peng/dsh-footer-order](https://github.com/Choi-Peng/dsh-footer-order) — DSH Web plugin that fixes multiple plugin entries crowding into one line in the sidebar footer (`sidebar.footer.action` slot) and lets you configure their stacking order.
 - [hanzhaoxuan2991479447-del/deepseek-harness-custom-bg](https://github.com/hanzhaoxuan2991479447-del/deepseek-harness-custom-bg) — Dynamic background plugin for the DeepSeek Harness Web UI: multi-image import, drag-to-reorder, auto-rotation, and blend/theme adaptation.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1454,6 +1454,7 @@ _多步 / 多 agent 调度器与输出聚合器。_
 ## UI / 客户端
 
 _DSH 的桌面、网页、终端或编辑器前端。_
+- [WilliamShi666/dsh-multiple-chat-panels](https://github.com/WilliamShi666/dsh-multiple-chat-panels) —— DeepSeek Harness 多对话面板：并排查看并与多个 Agent 同时交互。
 
 - [Choi-Peng/dsh-footer-order](https://github.com/Choi-Peng/dsh-footer-order) —— 一个 DeepSeek Harness 的 Web 端插件,解决侧边栏底部(sidebar.footer.action 槽位)多个插件内容挤成一行的布局问题,并让你自由配置这些内容的上下排列顺序。
 - [hanzhaoxuan2991479447-del/deepseek-harness-custom-bg](https://github.com/hanzhaoxuan2991479447-del/deepseek-harness-custom-bg) —— DeepSeek Harness Web 动态背景插件：多图导入、拖拓排序、自动轮换、融入度与主题自适应。


### PR DESCRIPTION
**dsh-multiple-chat-panels：DeepSeek Harness 多对话面板**

**dsh-multiple-chat-panels: Multiple chat panels for DeepSeek Harness**

---

在终端里使用 TUI 形态的 Agent（例如 Claude Code），你会获得一种“一览众山小”的上帝视角：可以同时查看和操控多个对话窗口，并与多个 Agent 并行互动。但很多桌面端或网页端的 Harness 并不支持这种能力：要么只能在一个对话里和一个 Agent 交互，要么即使支持多 Agent / 多窗口，操作也非常繁琐。

Terminal-native Agents (like Claude Code) give you a “god’s-eye view”: you can watch and steer multiple conversations at once, and interact with several Agents in parallel. Most desktop and web harnesses don’t offer this: you either work with a single Agent in a single conversation, or interacting with multiple agents in working in multiple sessions can be quite cumbersome.

![Claude Code 终端中的多对话窗口](https://raw.githubusercontent.com/WilliamShi666/dsh-multiple-chat-panels/main/docs/screenshots/claude-code-terminal.jpg)

![Claude Code in a terminal with multiple conversation panes](https://raw.githubusercontent.com/WilliamShi666/dsh-multiple-chat-panels/main/docs/screenshots/claude-code-terminal.jpg)

multiple-chat-panels 把这种体验带到了 DeepSeek Harness：你只需把左侧边栏里的对话拖到中间区域，Mission Control 就会把每个会话展开为一个可实时交互的独立面板。有了这样“一览众山小”的上帝视角，你可以显著提升与多个 Agent 的交互能力，以及多任务（multitasking）的执行能力；无需离开桌面端或网页端 UI。支持深色与浅色模式。

multiple-chat-panels brings that same experience to DeepSeek Harness. Drag conversations from the left sidebar into the center area, and Mission Control opens with each session as a live, independently interactive panel. With this “god’s-eye view”, you can significantly improve how you interact with multiple Agents and how you handle multitasking, all without leaving your desktop or web UI. Available in both dark and light mode.

![DeepSeek Harness 多对话面板 · 深色模式](https://raw.githubusercontent.com/WilliamShi666/dsh-multiple-chat-panels/main/docs/screenshots/dark.jpg)

![DeepSeek Harness multi-chat panels in dark mode](https://raw.githubusercontent.com/WilliamShi666/dsh-multiple-chat-panels/main/docs/screenshots/dark.jpg)

![DeepSeek Harness 多对话面板 · 浅色模式](https://raw.githubusercontent.com/WilliamShi666/dsh-multiple-chat-panels/main/docs/screenshots/light.jpg)

![DeepSeek Harness multi-chat panels in light mode](https://raw.githubusercontent.com/WilliamShi666/dsh-multiple-chat-panels/main/docs/screenshots/light.jpg)

## 安装 / Installation

```bash
dsh plugin --profile web add multiple-chat-panels
```

也可以直接从 GitHub 安装 / Or install directly from GitHub:

```bash
dsh plugin --profile web add github:WilliamShi666/dsh-multiple-chat-panels
```

安装后重启 DSH，把侧边栏中的会话拖到中间区域即可打开 Mission Control。/ Restart DSH, then drag a conversation from the sidebar into the center area to open Mission Control.

## 链接 / Links

- GitHub: https://github.com/WilliamShi666/dsh-multiple-chat-panels
- npm: https://www.npmjs.com/package/multiple-chat-panels
- 完整功能与开发状态 / Full features: https://github.com/WilliamShi666/dsh-multiple-chat-panels/blob/main/docs/FEATURES.md
- 发布/开源操作 / Release guide: https://github.com/WilliamShi666/dsh-multiple-chat-panels/blob/main/RELEASING.md

## License

MIT