### PR TITLE
add: Andiii208/dsh-ultramath (math-modeling agent skill pack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2138,6 +2138,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 ## Skills
 
 _Packaged task capabilities (markdown-based skills, tool packs)._
+- [Andiii208/dsh-ultramath](https://github.com/Andiii208/dsh-ultramath) — Math-modeling contest agent workflow for DeepSeek Harness: an "UltraMath" master preset runs a problem from reading through framework, derivation, coding, verification, paper and review, plus 4 single-stage role presets (mathematician, engineer, writer, reviewer) and 33 model-library skill docs.
 - [sfeng49/ashare-agent](https://github.com/sfeng49/ashare-agent) — A-share (China A-stock) research and review workbench: AKShare data-fetching, daily morning report, and trade review skills, plus backtest and stock-screener scripts — analysis only, no trading.
 - [HiccupGeng/dsh-doc-skill](https://github.com/HiccupGeng/dsh-doc-skill) — 规范文档生成技能（源自 Claude Code /doc 命令）：在 docs/ 下生成 yyyy_MM_dd_HH_<文档名>.md 规范文档，7 类文档类型感知检查清单，纯 Markdown 零依赖复制即用。
 - [caoqinnan-web/organize-workspace-sessions](https://github.com/caoqinnan-web/organize-workspace-sessions) — Organize DeepSeek Harness workspace sessions: rename them as Category｜Topic via the host's local RPC (workspace.list / session.list / session.history / session.rename) and report archive/rename/judgment suggestions — no archiving, because DSH has no archive-view entry.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2103,6 +2103,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 ## Skill
 
 _打包好的任务能力（基于 markdown 的 skill、工具包）。_
+- [Andiii208/dsh-ultramath](https://github.com/Andiii208/dsh-ultramath) —— 数学建模竞赛多 Agent 求解技能包：「UltraMath」主控预设一个预设跑通 读题→框架→推导→编码→验算→论文→审稿 全流程，另有 数学家/工程师/作家/审稿人 4 个单阶段角色预设与 33 篇模型库技能文档。
 - [sfeng49/ashare-agent](https://github.com/sfeng49/ashare-agent) —— A 股研究与复盘工作台：基于 AKShare 的数据获取、每日晨报、交易复盘三大技能，另附回测与选股脚本骨架，只做分析，不做交易。
 - [chenyinrusi/dsh-engineering-skills](https://github.com/chenyinrusi/dsh-engineering-skills) —— 面向 AI 编程 agent（DeepSeek Harness / Claude Code / Codex）的五个工程纪律技能：18 维度代码审查、CI 故障分流修复、shell 安全、冗余/边界审计与跨仓库模式吸收——纯 markdown，零安装。
 - [write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay) —— 中文长剧本写作 skill（SKILL.md）：双输入板块 + 因果—价值内核，内置去 AI 味审查与连续性台账，支撑 100 场以上长篇幅项目。


### PR DESCRIPTION
## What

Add **[Andiii208/dsh-ultramath](https://github.com/Andiii208/dsh-ultramath)** to the **Skills** section, one line in each locale (pure insertions, both READMEs kept in sync).

- **What**: UltraMath 数学建模竞赛多 Agent 求解 DSH 插件 — 「UltraMath」主控预设 + 数学家/工程师/作家/审稿人 4 个单阶段角色预设 + 33 篇模型库技能文档，覆盖 读题→框架→推导→编码→验算→论文→审稿 全流程。
- **How to install**: `dsh plugin --profile web add github:Andiii208/dsh-ultramath` (or `dsh plugin --profile web add dsh-ultramath` — published on npm as dsh-ultramath@0.3.0)
- **Repo facts (verifiable in the repo)**: 5 preset dirs under `presets/` (`ultramath` + `ultramath-{mathematician,engineer,writer,reviewer}`), 33 skill docs under `skills/模型库/`, `dsh.bundle.patch` → `cordis.patch.yml` (insert id=ultramath); carries `dsh`, `dsh-plugin`, `deepseek-harness` GitHub topics.

### Verification

- Link resolves: https://github.com/Andiii208/dsh-ultramath
- Topics: `dsh` / `dsh-plugin` / `deepseek-harness` all set on the repo
- Diff is pure insertions: `git diff` shows only `+` lines
- npm: https://www.npmjs.com/package/dsh-ultramath (0.3.0)
