### PR TITLE
Add Tabbit-Browser/dsh-plugin to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1416,6 +1416,7 @@ _Reusable sub-agents / specialized agent packs runnable inside DSH._
 - [omdsh-dev/dsh-tool-browser](https://github.com/omdsh-dev/dsh-tool-browser) — Static Cordis overlay and integration guide for the official `dsh-tool-browser` browser-control tool.
 - [PangYiMing/dsh-browser-control](https://github.com/PangYiMing/dsh-browser-control) — Browser-control plugin (CDP/Playwright).
 - [PangYiMing/dsh-mobile-control](https://github.com/PangYiMing/dsh-mobile-control) — Mobile-device control plugin (ADB/iOS).
+- [Tabbit-Browser/dsh-plugin](https://github.com/Tabbit-Browser/dsh-plugin) — Tabbit Browser plugin for DeepSeek Harness: ships a bundled `tabbit-browser` skill and `tabbit_browser_install` tool so the agent can drive the user's Tabbit Browser (CN/international, ≥1.9.0) via its Playwright CLI runtime, with background installer download when missing or outdated.  `⭐90`
 - [titanwings/dsh-better-browser](https://github.com/titanwings/dsh-better-browser) — Lets agents drive the user's signed-in browser through thirteen Kimi WebBridge tools.
 - [UynajGI/dsh-ssh](https://github.com/UynajGI/dsh-ssh) — SSH remote-execution plugin: ProxyJump chains, SFTP filesystem, subprocess and PTY over ssh2.
 - [whiteguo233/OpenBiliClaw](https://github.com/whiteguo233/OpenBiliClaw) — Local-first cross-platform content-discovery agent (Bilibili, Xiaohongshu, YouTube, X, etc.) that ships a DSH client plugin.  `⭐1926`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1400,6 +1400,7 @@ _可在 DSH 内运行的可复用子 agent / 专用 agent 包。_
 - [omdsh-dev/dsh-tool-browser](https://github.com/omdsh-dev/dsh-tool-browser) —— 官方 `dsh-tool-browser` 浏览器控制工具的静态 Cordis overlay 与集成指南。
 - [PangYiMing/dsh-browser-control](https://github.com/PangYiMing/dsh-browser-control) —— 操控浏览器插件（CDP/Playwright）。
 - [PangYiMing/dsh-mobile-control](https://github.com/PangYiMing/dsh-mobile-control) —— 操控手机设备插件（ADB/iOS）。
+- [Tabbit-Browser/dsh-plugin](https://github.com/Tabbit-Browser/dsh-plugin) —— Tabbit 浏览器的 DeepSeek Harness 插件：捆绑 `tabbit-browser` Skill 与 `tabbit_browser_install` 工具，让 Agent 通过 Playwright CLI 运行时操控本机 Tabbit（国内/国际正式版，≥1.9.0）；未安装或版本过低时后台下载安装包。  `⭐90`
 - [titanwings/dsh-better-browser](https://github.com/titanwings/dsh-better-browser) —— 通过 13 个 Kimi WebBridge 工具，让 Agent 操作用户已登录的真实浏览器。
 - [UynajGI/dsh-ssh](https://github.com/UynajGI/dsh-ssh) —— SSH 远程执行插件：ProxyJump 链、SFTP 文件系统、基于 ssh2 的子进程与 PTY。
 - [whiteguo233/OpenBiliClaw](https://github.com/whiteguo233/OpenBiliClaw) —— 本地优先的跨平台内容发现 Agent（B站/小红书/YouTube/X 等），并提供 DSH 客户端插件。  `⭐1926`


### PR DESCRIPTION
List the official Tabbit Browser DSH plugin so agents can drive Tabbit via its Playwright CLI runtime, with a bundled skill and installer tool.

<!-- Thanks for contributing to Awesome DeepSeek Harness! -->

## What are you adding?

- **Name:**
- **Link:**
- **Category:**
- **One-line description:**

## Checklist

- [x] The repo carries the `#dsh` GitHub topic
- [x] I edited **both** `README.md` and `README.zh-CN.md`
- [x] Entry follows the format: `- [Name](url) — description.`
- [x] Description is factual and hype-free
- [x] The project is real, working, and publicly accessible
