### PR TITLE
Add AgentValet/dsh-agentvalet under Security & Permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [aa2246740/dsh-auto-review](https://github.com/aa2246740/dsh-auto-review) — Codex-style Auto-review and Approve-for-me mode for DeepSeek Harness.
 - [xingyingyuzhui/dsh-agent-gate](https://github.com/xingyingyuzhui/dsh-agent-gate) — Claw/session permission gate and audit for DeepSeek Harness: intercepts, approves, and audits.
 - [PerryLink/dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) — Claude Code-style declarative permission rules (allow/deny/ask).
+- [AgentValet/dsh-agentvalet](https://github.com/AgentValet/dsh-agentvalet) — Brokered SaaS access: four tools reach approved platforms through a credential broker, minting a short-lived assertion per call, so no API key sits on the machine and every call is owner-approvable, revocable, and audited.
 - [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) — Secondary-model automatic review of approval requests.
 - [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) — Security-audit skill pack (secret scanning, dependency audit).
 - [agentic-control-plane/dsh-acp-plugin](https://github.com/agentic-control-plane/dsh-acp-plugin) — Policy checks before tool calls execute.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -525,6 +525,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 - [uson1x/dsh-plugin-llm-verifier](https://github.com/uson1x/dsh-plugin-llm-verifier) —— LLM-as-a-Verifier for DeepSeek Harness：通过 select / compare / track 提供持续奖励信号。
 - [xingyingyuzhui/dsh-agent-gate](https://github.com/xingyingyuzhui/dsh-agent-gate) —— 面向 DeepSeek Harness 的 Claw/会话权限门与审计。拦截、审批、审计。
 - [PerryLink/dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) —— Claude Code 式声明权限规则（allow/deny/ask）。
+- [AgentValet/dsh-agentvalet](https://github.com/AgentValet/dsh-agentvalet) — 代理式 SaaS 访问：四个工具经凭据代理调用已授权平台，每次调用签发短期断言，机器上不存任何 API key，每次调用都可由所有者审批、撤销并留存审计。
 - [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) —— 二次模型自动审核 approval 请求。
 - [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) —— 安全审计 skill 包（密钥扫描/依赖审计）。
 - [agentic-control-plane/dsh-acp-plugin](https://github.com/agentic-control-plane/dsh-acp-plugin) —— 工具调用前的 policy-check。


### PR DESCRIPTION
One entry, added to both `README.md` and `README.zh-CN.md` under **Security & Permissions**, in the required format.

**[AgentValet/dsh-agentvalet](https://github.com/AgentValet/dsh-agentvalet)** — four tools that reach approved SaaS platforms through a credential broker. A short-lived assertion is minted per call, so no API key sits on the machine and every call is owner-approvable, revocable, and audited.

Complements rather than repeats what's already in this section. The existing entries decide whether a tool call is allowed to proceed on this machine; this one changes where the credential lives, so for a SaaS call the enforceable boundary becomes whether a credential is issued at all. A sandbox governs the filesystem; it does not govern Slack or Stripe.

Checklist:
- Repo tagged with the **`dsh`** topic ✅ (also `dsh-plugin`, `deepseek-harness`)
- Both READMEs edited and kept in sync ✅
- Exact entry format ✅

Published as `@agentvalet/dsh`, MIT. `package.json#dsh.bundle` → `cordis.patch.yml`, harness range `>=0.1.0-rc.5 <0.2.0`. Verified against 0.1.0-rc.7: packed tarball installed into a real headless profile, both rows present in `--dump-config`, all four tools registering at runtime.

The Chinese line is my own translation — corrections welcome.