### PR TITLE
add zhengjy01/dsh-skill-studio under Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -2984,6 +2984,7 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [uckkk/dsh-payroll-net](https://github.com/uckkk/dsh-payroll-net) — Net (post-tax) payroll calculator.
 - [wyzh0117/dsh-skill-select](https://github.com/wyzh0117/dsh-skill-select) — DSH web plugin: pick skills from a sidebar and inject them into the current session.
 
+- [zhengjy01/dsh-skill-studio](https://github.com/zhengjy01/dsh-skill-studio) — Skill studio for DeepSeek Harness: visualize every agent skill (name, description, source root, nested flag, model/user invocation state), view/edit the full SKILL.md body, and enable or disable model/user invocation — from the web settings panel and via skillmgr_* tools.
 ## Resources
 
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) — Official source repo.  `⭐38238`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2921,6 +2921,7 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [uckkk/dsh-kg2lb](https://github.com/uckkk/dsh-kg2lb) —— 千克转磅换算工具。
 - [uckkk/dsh-payroll-net](https://github.com/uckkk/dsh-payroll-net) —— 税后工资计算器。
 - [wyzh0117/dsh-skill-select](https://github.com/wyzh0117/dsh-skill-select) —— DSH web 插件：从侧边栏选择技能并注入到当前会话。
+- [zhengjy01/dsh-skill-studio](https://github.com/zhengjy01/dsh-skill-studio) —— DSH skill 可视化与管理插件：在设置面板列出全部 skill（含来源、嵌套标记与模型/用户调用状态），查看并编辑 SKILL.md 正文，一键启用/禁用模型与用户调用；同时提供 skillmgr_list/get/save/policy 工具。
 ## 资源
 
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) —— 官方源码仓库。  `⭐38238`


### PR DESCRIPTION
Add [zhengjy01/dsh-skill-studio](https://github.com/zhengjy01/dsh-skill-studio) to the **Skills** section (both README files).

Skill studio for DeepSeek Harness: visualize every agent skill (name, description, source root, nested flag, model/user invocation state), view/edit the full SKILL.md body, and enable or disable model/user invocation — from the web settings panel and via skillmgr_* tools.

Repo carries dsh/dsh-plugin/deepseek-harness topics.