### PR TITLE
docs: add MemSearch and dsh-milvus

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,8 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [tmpdot/dsh-audit-foundation](https://github.com/tmpdot/dsh-audit-foundation) — Trust Anchor: the security & audit foundation of the DeepSeek Harness ecosystem — Minimal Design Principles spec package plus minimal-responsibility plugins nailing down the policy → enforcement → evidence → storage → query → presentation → response → audit-consumption interfaces.
 ## Session & Memory Management
 
+- [zilliztech/memsearch](https://github.com/zilliztech/memsearch/tree/main/plugins/dsh) — Shared Markdown memory for DSH and other coding agents, with automatic capture, pre-step context injection, searchable recall, and a review panel.
+
 _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 
 - [TsFreddie/dsh-compaction-instant](https://github.com/TsFreddie/dsh-compaction-instant) — LLM-free lossless* compaction engine for DeepSeek Harness.
@@ -1586,6 +1588,8 @@ _Generate presentations, decks, slide exports._
 ## Coding
 
 _Code generation, refactoring, review, repo-level engineering plugins._
+
+- [zilliztech/dsh-milvus](https://github.com/zilliztech/dsh-milvus) — Read-only DSH Web plugin for inspecting and searching Milvus or Zilliz Cloud collections from chat, including scalar, BM25, dense, and hybrid queries.
 
 - [lemonxiny55/dsh-code-index](https://github.com/lemonxiny55/dsh-code-index) — Semantic repo index plugin: tree-sitter symbol index, ranked symbol search, and a bounded auto-updating repo map injected into the system prompt — fills the gap left by dsh's lack of an aider-style repo-map / Cursor `@Codebase` capability.
 - [lvxinrong/dsh-archscope](https://github.com/lvxinrong/dsh-archscope) — Evidence-driven system architecture reconnaissance for DeepSeek Harness.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -751,6 +751,8 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 - [tmpdot/dsh-audit-foundation](https://github.com/tmpdot/dsh-audit-foundation) —— Trust Anchor：DeepSeek Harness 生态的安全与审计基础设施——最小设计原则规范包，加上一组最小职责插件，钉死策略 → 执行 → 证据 → 存储 → 查询 → 展示 → 响应 → 审计消费全链路接口。
 ## 会话与记忆管理
 
+- [zilliztech/memsearch](https://github.com/zilliztech/memsearch/tree/main/plugins/dsh) —— 供 DSH 与其他编程 Agent 共享的 Markdown 记忆，支持自动捕获、步骤前上下文注入、搜索召回与审阅面板。
+
 _跨会话记忆、checkpoint、会话置顶与导航插件。_
 
 - [TsFreddie/dsh-compaction-instant](https://github.com/TsFreddie/dsh-compaction-instant) —— 面向 DeepSeek Harness 的无 LLM、无损（近似）压缩引擎。
@@ -1576,6 +1578,8 @@ _生成演示文稿、幻灯片、导出 PPT。_
 ## 写代码
 
 _代码生成、重构、审查、仓库级工程插件。_
+
+- [zilliztech/dsh-milvus](https://github.com/zilliztech/dsh-milvus) —— 只读 DSH Web 插件，可在对话中检查和搜索 Milvus 或 Zilliz Cloud Collection，支持标量、BM25、稠密向量与混合查询。
 
 - [lemonxiny55/dsh-code-index](https://github.com/lemonxiny55/dsh-code-index) —— 语义代码仓索引插件：基于 tree-sitter 的符号索引、排序符号搜索，并将有界的自动更新仓库地图注入系统提示词 —— 补充 dsh 缺失的类似 aider repo-map / Cursor `@Codebase` 能力。
 - [lvxinrong/dsh-archscope](https://github.com/lvxinrong/dsh-archscope) —— 面向 DeepSeek Harness 的证据驱动式系统架构侦察。


### PR DESCRIPTION
## What are you adding?

- **Names:** MemSearch and dsh-milvus
- **Links:** https://github.com/zilliztech/memsearch/tree/main/plugins/dsh and https://github.com/zilliztech/dsh-milvus
- **Categories:** Session & Memory Management; Coding
- **Descriptions:** Shared Markdown memory and read-only Milvus collection inspection/search.

## Checklist

- [x] Both repositories carry the `dsh-plugin` GitHub topic
- [x] Both `README.md` and `README.zh-CN.md` are updated
- [x] Entries follow the required bilingual format
- [x] Descriptions are factual and hype-free
- [x] Both projects are public, working, and published to npm
- [x] The diff is insert-only and limited to the two README files

cc @Dominic789654