### PR TITLE
Auto-add 17 DSH plugins (20260824 scan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [lengquan88/dsh-dual-auto](https://github.com/lengquan88/dsh-dual-auto) — Dual-model auto-routing plugin for DeepSeek Harness: low-cost direct / high-cost upgrade + escape-learning closed loop.
 - [steven95/dsh-office-suite](https://github.com/steven95/dsh-office-suite) — Office-suite plugin for DeepSeek Harness (dsh-plugin).
 - [Yiklek/dsh-web-profile](https://github.com/Yiklek/dsh-web-profile) — DeepSeek Harness Web profile plugin (deepseek-harness, dsh-plugin).
+- [xswt442-cmd/dsh-instance-manager](https://github.com/xswt442-cmd/dsh-instance-manager) — Sidebar panel to list and gracefully stop local dsh web instances on ports 3080-3129.
 
 ## Security & Permissions
 
@@ -1022,6 +1023,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [WSL043/dsh-native-session-manager](https://github.com/WSL043/dsh-native-session-manager) — DSH Native Session Manager for DeepSeek Harness: search archived conversations, restore sessions, and safely delete chat history.
 - [gjj-star/dsh-conversation-navigator](https://github.com/gjj-star/dsh-conversation-navigator) — DSH conversation navigator plugin.
 - [Whale-Zhang/dsh-cron-tasks](https://github.com/Whale-Zhang/dsh-cron-tasks) — Scheduled tasks for DeepSeek Harness: sidebar jobs, isolated run history, cron/at schedules.
+- [NattoCB/dsh-plugin-pin-session](https://github.com/NattoCB/dsh-plugin-pin-session) — Pin sessions in the DeepSeek Harness web GUI: Pinned Sessions group above the sidebar list + Pin/Unpin in the session row menu.
 
 ## Cost & Usage Tracking
 
@@ -1214,6 +1216,7 @@ _Token usage, cost dashboards, and budget-alert plugins._
 - [WSL043/dsh-native-deepseek-balance](https://github.com/WSL043/dsh-native-deepseek-balance) — Compact, private DeepSeek API cash balance widget for DeepSeek Harness.
 - [Phant0Meow/dsh-meow-cachebilling](https://github.com/Phant0Meow/dsh-meow-cachebilling) — Money-saving cache billing plugin for DeepSeek Harness: shows exactly how much the current turn's pure context-cache portion has cost you, so you know when it's worth switching windows.
 - [statem-li/dsh-usage-skill](https://github.com/statem-li/dsh-usage-skill) — Token usage analytics, provider balances, and skill bundle management for the dsh web GUI.
+- [xuanfengtechx/dsh-openrouter-provider-advisor](https://github.com/xuanfengtechx/dsh-openrouter-provider-advisor) — DSH plugin that ranks OpenRouter providers by cost, speed, context, and reliability, then switches the active route.
 
 ## Channel / IM Bridges
 
@@ -1808,6 +1811,8 @@ _Code generation, refactoring, review, repo-level engineering plugins._
 - [win4r/dsh-pi-review](https://github.com/win4r/dsh-pi-review) — Read-only Pi Agent code review plugin for DeepSeek Harness.
 - [lhbsaa/dsh-visibridge](https://github.com/lhbsaa/dsh-visibridge) — DeepSeek Harness vision plugin: analyze_image (structured OCR evidence) + capture_image (USB camera visual loop), with Ollama / DeepSeek / Xiaomi backends.
 - [launchmaniac/dsh-media-tools](https://github.com/launchmaniac/dsh-media-tools) — OpenRouter image, video, and speech generation as deepseek-harness tools — an out-of-tree profile bundle, no fork required.
+- [Cyning12/dsh-coding-kit](https://github.com/Cyning12/dsh-coding-kit) — DSH plugin + gate CLI for ICVO coding standards (load ≠ inject: call apply_coding_standards). CLI: `npx dsh-coding-kit`.
+- [initial-d/dsh-plugin-mlquant-benchmark](https://github.com/initial-d/dsh-plugin-mlquant-benchmark) — DeepSeek Harness tools for reproducing the ml-quant-trading protocol v1 benchmark.
 
 ## Agents
 
@@ -1835,6 +1840,7 @@ _Reusable sub-agents / specialized agent packs runnable inside DSH._
 - [yaways/dsh-subagent-claude-code-wrapper](https://github.com/yaways/dsh-subagent-claude-code-wrapper) — Claude Code subagent provider for DeepSeek Harness with a configurable CLI executable path, forked from @deepseek-ai/dsh-subagent-claude-code.
 - [PerryLink/dsh-industry-research](https://github.com/PerryLink/dsh-industry-research) — Industry and company research domain pack for DeepSeek Harness: methodology skills, industry chain mapping, public-source policy/news tracking, company research cards, and auditable research reports. Research only - not investment advice.
 - [hancao97/hanai-investment-dsh](https://github.com/hancao97/hanai-investment-dsh) — Local-first A-share research workbench for DeepSeek Harness: market dashboards, watchlists, valuation, four investor agents, versioned reports, and continuous post-report chat.
+- [ktdhhc/dsh-custom-subagents](https://github.com/ktdhhc/dsh-custom-subagents) — A DSH sub-agent control plugin.
 - [Mr-Neutr0n/dsh-medseek](https://github.com/Mr-Neutr0n/dsh-medseek) — Clinical tools for DeepSeek Harness: handover and discharge drafts, de-identification, completeness checks, and cited lookups. Draft-only, not a medical device.
 - [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) — Verifiable research-report engine for DeepSeek Harness: content-addressed evidence ledger (claim-snapshot binding, tamper-evident) plus versioned sealed reports with per-claim verification verdicts and a manifest-sealed directory.
 - [bpc-oss/dsh-verification](https://github.com/bpc-oss/dsh-verification) — Verification gate for agents: every acceptance criterion must be backed by server-stamped real tool evidence before the completion gate lets a goal through (advisory audit, enforce gate, durable permits).
@@ -2060,6 +2066,7 @@ _Model Context Protocol servers that contribute tools / prompts / resources to D
 - [querit-ai/querit-plugins](https://github.com/querit-ai/querit-plugins) — Official Querit search plugins for AI agent harnesses: pi-querit (Pi extension), dsh-querit (DeepSeek Harness web seam), opencode-querit (OpenCode plugin).
 - [edusrez/dsh-tool-web-enhanced](https://github.com/edusrez/dsh-tool-web-enhanced) — Modular search tool for DeepSeek Harness: attach SearXNG, RAG and your own sections to the native web_search.
 - [Wiselfx/dsh-freeweb](https://github.com/Wiselfx/dsh-freeweb) — Keyless WebSearchProvider for DeepSeek Harness's ctx.web seam: fans out to DuckDuckGo, Startpage, and Perplexity (plus optional Firecrawl), merging results by cross-engine consensus — no API keys, no signup.
+- [nicecx/dsh-macos-calendar](https://github.com/nicecx/dsh-macos-calendar) — DSH host-side plugin: real macOS Calendar integration (create/list/query/delete events via AppleScript) for DeepSeek Harness agents.
 
 ## Orchestrators & Aggregators
 
@@ -2155,6 +2162,9 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [iguowz/dsh-cortex](https://github.com/iguowz/dsh-cortex) — Low-cost multi-model orchestration plugin (Cortex): large model plans and reviews, small sub-agent models execute, cutting cost while preserving quality.
 - [DevViking-Persike/dsh-subscriptions](https://github.com/DevViking-Persike/dsh-subscriptions) — DeepSeek Harness plugin: use your own Claude and ChatGPT/Codex subscriptions as model providers, over each vendor's OAuth sign-in.
 - [zsagi1368/deepseek-harness-zDSH](https://github.com/zsagi1368/deepseek-harness-zDSH) — zDSH — deepseek-harness independent enhancement distro: plugin governance, omnivision vision pipeline, cross-session memory, mobile-ready web UI.
+- [Fly2Kiana/Codex-DSH-Orchestrator](https://github.com/Fly2Kiana/Codex-DSH-Orchestrator) — Codex-first orchestration layer and caller-side MCP bridge for bounded collaboration with DeepSeek Harness (DSH).
+- [monotykamary/dsh-factory](https://github.com/monotykamary/dsh-factory) — Durable dependency-graph task factory for DeepSeek Harness: recurring Agent work, safe checkout lanes, first-class queues, Triage, and artifacts.
+- [newbieYi/dsh-dify-builder](https://github.com/newbieYi/dsh-dify-builder) — Build local Dify workflows through real-time conversation in DeepSeek Harness.
 ## UI / Clients
 - [776138506/pinpoint](https://github.com/776138506/pinpoint) — Point-and-annotate on any webpage, then send the screenshot plus structured text straight into a DSH session (DSH plugin + browser extension).
 - [Alain-Prot0s5/dsh-screenshot](https://github.com/Alain-Prot0s5/dsh-screenshot) — Screenshot-to-input plugin for DeepSeek Harness Desktop (DSH Desktop app required; Windows 10/11 only): camera button and global hotkey Alt+A snip and auto-paste into the composer.
@@ -3068,6 +3078,12 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [SkuraSshly/dsh-done-badge](https://github.com/SkuraSshly/dsh-done-badge) — DeepSeek Harness (DSH) task completion badge: native Windows taskbar counter (ITaskbarList3) while the window is away, auto-clears on return. Subagent sessions excluded.
 - [v587d/dsh-anysearch-refs](https://github.com/v587d/dsh-anysearch-refs) — A DSH sidebar plugin that shows AnySearch references as cards, with the search query, source snippets and highlighted keywords in the right sidebar.
 - [zhili-wang/dsh-open-in-vscode](https://github.com/zhili-wang/dsh-open-in-vscode) — DeepSeek Harness (dsh) Web plugin: one-click open the workspace in VS Code, click a file path in a conversation to jump to it in VS Code (supports file:line:column).
+- [AxelGoal/Deepharn](https://github.com/AxelGoal/Deepharn) — A dedicated macOS desktop for DeepSeek Harness: a new frontend on top of its API, a native Swift shell, and two plugins.
+- [cofy-x/dsh-console](https://github.com/cofy-x/dsh-console) — A TypeScript and React/Ink terminal frontend for DeepSeek Harness.
+- [ggban666/deepseek-harness-diechi](https://github.com/ggban666/deepseek-harness-diechi) — One-click integrated edition of DeepSeek Harness (DSH): a local AI workbench with MiniCPM-V real-time vision, Kokoro voice chat, accessibility skills, and a global brain.
+- [rayafriandion/dsh-oc-tui](https://github.com/rayafriandion/dsh-oc-tui) — A plugin that brings a terminal UI like opencode/Claude Code and other CLI/TUI agents to DeepSeek Harness.
+- [rison114514/dsh-endfield-ui](https://github.com/rison114514/dsh-endfield-ui) — Endfield-inspired industrial UI shell for DeepSeek Harness (dsh) — non-official fan theme. Install: `dsh plugin --profile web add @rison/dsh-endfield-ui`.
+- [WizisCool/dsh-ears](https://github.com/WizisCool/dsh-ears) — A voice-input plugin for DeepSeek Harness that supports multiple ASR backends and polishing through dsh's own LLM route.
 
 ## Skills
 
@@ -3256,6 +3272,7 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [Mikuzjc/dsh-office-for-mso](https://github.com/Mikuzjc/dsh-office-for-mso) — DeepSeek Harness plugin/skill: control open Word/Excel/PowerPoint via an Office add-in (33 actions, AI-orchestrated, near-Copilot workflows).
 - [maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge) — DeepSeek Harness tools for self-hosted Gitea and Forgejo instances.
 - [maxmilian/dsh-sonarqube](https://github.com/maxmilian/dsh-sonarqube) — Read-only SonarQube Community Build tools for DeepSeek Harness.
+- [SLin-code/dsh-skill-manager](https://github.com/SLin-code/dsh-skill-manager) — Minimal, security-focused local Skill Manager for DeepSeek Harness Web.
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -626,6 +626,7 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [lengquan88/dsh-dual-auto](https://github.com/lengquan88/dsh-dual-auto) —— DeepSeek Harness 的双模型自动路由插件：低成本直接 / 高成本升级 + 逃逸学习闭环。
 - [steven95/dsh-office-suite](https://github.com/steven95/dsh-office-suite) —— DeepSeek Harness 的办公套件插件（dsh-plugin）。
 - [Yiklek/dsh-web-profile](https://github.com/Yiklek/dsh-web-profile) —— DeepSeek Harness Web profile 插件（deepseek-harness, dsh-plugin）。
+- [xswt442-cmd/dsh-instance-manager](https://github.com/xswt442-cmd/dsh-instance-manager) —— DSH 常驻插件：侧边栏面板统一查看并停止本机 3080–3129 端口的 dsh 实例。
 - [Frog755/dsh-client-auto-retry](https://github.com/Frog755/dsh-client-auto-retry) —— DSH 客户端插件：当回合被中断/报错/过长时自动发送「继续」，不切换模型/提供商，自带设置卡。
 - [sanshanya/better-model-provider](https://github.com/sanshanya/better-model-provider) —— 面向 DeepSeek Harness 的每模型能力声明：推理强度档位（wire 拼写）+ 请求模态（vision），适用于 OpenAI 兼容提供商，设置面板、零运行时 harness 依赖、无 YAML。
 - [SouleyMoni1/dsh-experience-plugin](https://github.com/SouleyMoni1/dsh-experience-plugin) —— DSH 插件：为自定义 API 模型提供每模型推理档位，带族系预设与官方设置页编辑器。
@@ -1015,6 +1016,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [li3-feng2-jie2/dsh-motion-memory](https://github.com/li3-feng2-jie2/dsh-motion-memory) —— 适配 DeepSeek Harness（DSH）高自定义能力的一个记忆管理插件。
 - [gjj-star/dsh-conversation-navigator](https://github.com/gjj-star/dsh-conversation-navigator) — DSH 会话导航
 - [Whale-Zhang/dsh-cron-tasks](https://github.com/Whale-Zhang/dsh-cron-tasks) — DeepSeek Harness 定时任务插件：侧边栏任务列表、隔离运行历史、cron/at 定时调度。
+- [NattoCB/dsh-plugin-pin-session](https://github.com/NattoCB/dsh-plugin-pin-session) —— 在 DeepSeek Harness web GUI 中置顶会话：侧边栏列表上方的置顶会话分组，以及会话行菜单中的置顶/取消置顶。
 
 ## 成本与用量统计
 
@@ -1204,6 +1206,7 @@ _token 用量、成本看板与预算告警插件。_
 - [WSL043/dsh-native-deepseek-balance](https://github.com/WSL043/dsh-native-deepseek-balance) —— 精巧、隐私的 DeepSeek Harness DeepSeek API 现金余额插件。
 - [Phant0Meow/dsh-meow-cachebilling](https://github.com/Phant0Meow/dsh-meow-cachebilling) — 一个能帮你省钱的插件！缓存其实比你想象的贵！换窗口可以省缓存钱，但换窗口有顾虑，或许你懒得重新描述项目和规则，或者你还需要那个上下文。所以这个插件，就是为了告诉你，当前轮，纯粹上下文缓存的部分，到底花了你多少钱。这样你才心里有个底，判断什么时候该换窗口。
 - [statem-li/dsh-usage-skill](https://github.com/statem-li/dsh-usage-skill) — 面向 dsh Web GUI 的 Token 用量分析、供应商余额查询与技能包管理。
+- [xuanfengtechx/dsh-openrouter-provider-advisor](https://github.com/xuanfengtechx/dsh-openrouter-provider-advisor) —— DSH 插件：按成本、速度、上下文与可靠性对 OpenRouter 供应商排名，并切换当前使用的路由。
 
 ## Channel / IM 桥接
 
@@ -1793,6 +1796,8 @@ _代码生成、重构、审查、仓库级工程插件。_
 - [lhbsaa/dsh-visibridge](https://github.com/lhbsaa/dsh-visibridge) —— DeepSeek Harness 视觉插件：analyze_image（结构化 OCR 证据）+ capture_image（USB 摄像头视觉闭环），支持 Ollama / DeepSeek / 小米三后端。
 - [Tlyer233/dsh-vscode-review](https://github.com/Tlyer233/dsh-vscode-review) —— DeepSeek Harness 审核插件，可以让你在 VS Code 中直观看到 dsh 的“增删改”操作，支持逐行 ac 或 rj。
 - [launchmaniac/dsh-media-tools](https://github.com/launchmaniac/dsh-media-tools) —— 基于 OpenRouter 的图像、视频、语音生成作为 deepseek-harness 工具 —— 一个树外的 profile bundle，无需 fork。
+- [Cyning12/dsh-coding-kit](https://github.com/Cyning12/dsh-coding-kit) —— 面向 ICVO 编码规范的 DSH 插件 + 门禁 CLI：加载 ≠ 注入，需调用 apply_coding_standards。CLI：`npx dsh-coding-kit`。
+- [initial-d/dsh-plugin-mlquant-benchmark](https://github.com/initial-d/dsh-plugin-mlquant-benchmark) —— 用于复现 ml-quant-trading protocol v1 基准测试的 DeepSeek Harness 工具集。
 
 ## Agent
 
@@ -1918,6 +1923,7 @@ _可在 DSH 内运行的可复用子 agent / 专用 agent 包。_
 - [PyModel/dsh-research-plugins](https://github.com/PyModel/dsh-research-plugins) —— 面向 DeepSeek Harness 的研究类插件集合——一个 pnpm monorepo，为 DSH 智能体添加网页搜索与 MCP 桥接，支持 AI 研究、网页抓取与实时文档查阅。
 - [240xu/dsh-websearch](https://github.com/240xu/dsh-websearch) —— 面向 DSH 的统一网页搜索提供方。
 - [ABccgh/dsh-agent-studio](https://github.com/ABccgh/dsh-agent-studio) —— DSH 智能体与插件开发预设：为 DeepSeek Harness 构建 agent preset 与预设本地插件的开发智能体，含 preset_* 工具集、插件/技能脚手架、静态审查与挂载校验。
+- [ktdhhc/dsh-custom-subagents](https://github.com/ktdhhc/dsh-custom-subagents) —— 一个 dsh 的子 agent 控制插件。
 
 ## 循环（自动研究 / 自我改进等）
 
@@ -2037,6 +2043,7 @@ _向 DSH 贡献工具 / prompt / 资源的 Model Context Protocol server。_
 - [querit-ai/querit-plugins](https://github.com/querit-ai/querit-plugins) —— Querit 官方搜索插件，适配多种 AI agent harness：pi-querit（Pi 扩展）、dsh-querit（DeepSeek Harness web seam）、opencode-querit（OpenCode 插件）。
 - [edusrez/dsh-tool-web-enhanced](https://github.com/edusrez/dsh-tool-web-enhanced) —— 面向 DeepSeek Harness 的模块化搜索工具：为原生 web_search 挂载 SearXNG、RAG 与你自己的搜索模块。
 - [Wiselfx/dsh-freeweb](https://github.com/Wiselfx/dsh-freeweb) —— 面向 DeepSeek Harness ctx.web 接口的无需密钥 WebSearchProvider：同时发出 DuckDuckGo、Startpage 与 Perplexity 请求（可选 Firecrawl），跨引擎共识合并结果 —— 无需 API Key 与注册。
+- [nicecx/dsh-macos-calendar](https://github.com/nicecx/dsh-macos-calendar) —— DSH 宿主端插件：为 DeepSeek Harness 智能体提供真实的 macOS 日历集成（通过 AppleScript 实现创建/列出/查询/删除事件）。
 
 ## 编排器与聚合器
 
@@ -2133,6 +2140,9 @@ _多步 / 多 agent 调度器与输出聚合器。_
 - [iguowz/dsh-cortex](https://github.com/iguowz/dsh-cortex) —— 低成本多模型编排插件（Cortex）：大模型规划验收，子agent小模型执行，降本保质。
 - [DevViking-Persike/dsh-subscriptions](https://github.com/DevViking-Persike/dsh-subscriptions) —— DeepSeek Harness 插件：通过各厂商自己的 OAuth 登录，把你自己的 Claude 与 ChatGPT/Codex 订阅作为模型提供方使用。
 - [zsagi1368/deepseek-harness-zDSH](https://github.com/zsagi1368/deepseek-harness-zDSH) —— zDSH —— deepseek-harness 独立增强发行版：插件治理、全能视觉管线、跨会话记忆、移动适配 web UI。
+- [Fly2Kiana/Codex-DSH-Orchestrator](https://github.com/Fly2Kiana/Codex-DSH-Orchestrator) —— 以 Codex 为主导的编排层，并提供调用方 MCP 桥接，用于与 DeepSeek Harness (DSH) 实现有边界的协作。
+- [monotykamary/dsh-factory](https://github.com/monotykamary/dsh-factory) —— 面向 DeepSeek Harness 的持久依赖图任务工厂：循环 Agent 任务、安全的 checkout 车道、一等公民队列、Triage 以及产出物。
+- [newbieYi/dsh-dify-builder](https://github.com/newbieYi/dsh-dify-builder) —— 在 DeepSeek Harness 中通过实时对话构建本地 Dify 工作流。
 ## UI / 客户端
 
 _DSH 的桌面、网页、终端或编辑器前端。_
@@ -3020,6 +3030,12 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [SkuraSshly/dsh-done-badge](https://github.com/SkuraSshly/dsh-done-badge) — DeepSeek Harness (DSH) 任务完成徽标：窗口不在前台时使用原生 Windows 任务栏计数（ITaskbarList3），返回时自动清零，排除子代理会话。
 - [v587d/dsh-anysearch-refs](https://github.com/v587d/dsh-anysearch-refs) — 一个 DSH 侧边栏插件，把 AnySearch 的搜索结果以卡片形式展示在右侧侧边栏中，包括搜索词、来源摘要和关键词高亮。
 - [zhili-wang/dsh-open-in-vscode](https://github.com/zhili-wang/dsh-open-in-vscode) — DeepSeek Harness (dsh) Web 插件：工作区一键打开 VSCode，对话内文件路径点击跳转 VSCode（支持 文件:行:列）。
+- [AxelGoal/Deepharn](https://github.com/AxelGoal/Deepharn) —— 面向 DeepSeek Harness 的专属 macOS 桌面端：基于其 API 的全新前端、原生 Swift 外壳，附带两个插件。
+- [cofy-x/dsh-console](https://github.com/cofy-x/dsh-console) —— 面向 DeepSeek Harness 的 TypeScript 与 React/Ink 终端前端。
+- [ggban666/deepseek-harness-diechi](https://github.com/ggban666/deepseek-harness-diechi) —— DeepSeek Harness (DSH) 改版整合版 ｜ 蝶翅APP：一键启动的本地 AI 工作台，MiniCPM-V 实时视觉、Kokoro 语音对话、平权技能、全局大脑。
+- [rayafriandion/dsh-oc-tui](https://github.com/rayafriandion/dsh-oc-tui) —— 该插件可让 DeepSeek Harness 使用类似 opencode/Claude Code 等 CLI/TUI agent 的终端 UI。
+- [rison114514/dsh-endfield-ui](https://github.com/rison114514/dsh-endfield-ui) —— 灾变（Endfield）风格的工业 UI 外壳，面向 DeepSeek Harness (dsh) —— 非官方同人主题。安装：`dsh plugin --profile web add @rison/dsh-endfield-ui`。
+- [WizisCool/dsh-ears](https://github.com/WizisCool/dsh-ears) —— 面向 DeepSeek Harness 的语音输入插件，支持多种 ASR 后端，并可通过 dsh 自身的 LLM 路由进行润色。
 
 ## Skill
 
@@ -3193,6 +3209,7 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [Mikuzjc/dsh-office-for-mso](https://github.com/Mikuzjc/dsh-office-for-mso) —— DeepSeek Harness (DSH) 的 Office 技能：通过 Office 加载项操控已打开的 Word/Excel/PPT（33 项操作，AI 编排，接近 Copilot 的工作流）。
 - [maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge) — 面向自托管 Gitea / Forgejo 实例的 DeepSeek Harness 工具集。
 - [maxmilian/dsh-sonarqube](https://github.com/maxmilian/dsh-sonarqube) — 面向 DeepSeek Harness 的只读 SonarQube Community Build 工具集。
+- [SLin-code/dsh-skill-manager](https://github.com/SLin-code/dsh-skill-manager) —— 面向 DeepSeek Harness Web 的极简、安全优先的本地 Skill 管理器。
 
 ## 资源
 


### PR DESCRIPTION
自动扫描收录：新增 17 条社区 DSH 插件（去重后）。仅改 README.md / README.zh-CN.md。由每日扫描自动化生成，PR 巡检会自动核验链接真实性与格式后合并。