### PR TITLE
Add ZomiCC/ghost-refresh (UI plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3209,6 +3209,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [NIU-001-LIU/dsh-chat-timeline-plus](https://github.com/NIU-001-LIU/dsh-chat-timeline-plus) — DeepSeek Harness timeline with hover Q&A preview and panel pin.
 - [PaoMoXML/dsh-paste-names](https://github.com/PaoMoXML/dsh-paste-names) — Pastes non-image files/folders into the dsh chat composer as native @path references, replacing the image-only paste error.
 - [qingshanyuluo/dsh-mobile-ux](https://github.com/qingshanyuluo/dsh-mobile-ux) — DeepSeek Harness mobile: CSS-only UI plugin, password-protected Cloudflare tunnel, and a tiny Android WebView app — use DSH on your phone.
+- [ZomiCC/ghost-refresh](https://github.com/ZomiCC/ghost-refresh) — A friendly ghost drifts across the DSH web UI at random intervals to keep you awake; speed, opacity, size and frequency are adjustable and persisted per browser.
 
 ## Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3160,6 +3160,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [NIU-001-LIU/dsh-chat-timeline-plus](https://github.com/NIU-001-LIU/dsh-chat-timeline-plus) —— DeepSeek Harness 时间线插件：悬停预览问答、面板可固定。
 - [PaoMoXML/dsh-paste-names](https://github.com/PaoMoXML/dsh-paste-names) —— dsh 将非图片文件或文件夹以原生 @path 引用粘贴进聊天输入框，替代仅支持图片的报错。
 - [qingshanyuluo/dsh-mobile-ux](https://github.com/qingshanyuluo/dsh-mobile-ux) —— DeepSeek Harness 手机端：纯 CSS UI 插件、带密码保护的 Cloudflare 隧道，以及一个小型 Android WebView App —— 在手机上使用 DSH。
+- [ZomiCC/ghost-refresh](https://github.com/ZomiCC/ghost-refresh) —— 一只友好的小幽灵随机飘过 DSH 网页界面提神醒脑；速度、透明度、大小、频率可调并按浏览器持久保存。
 
 ## Skill
 


### PR DESCRIPTION
Adds one entry to UI / Clients (en + zh-CN):

- **Plugin:** [ZomiCC/ghost-refresh](https://github.com/ZomiCC/ghost-refresh) — a friendly ghost drifts across the DSH web UI at random intervals to keep you awake; speed/opacity/size/frequency adjustable and persisted per browser.
- Repo carries the #dsh and #dsh-plugin topics.
- npm package: [dsh-ghost-refresh](https://www.npmjs.com/package/dsh-ghost-refresh) (declares dsh.bundle).
- Entry appended at the end of the section (alphabetical, Z).