### PR TITLE
docs: add dsh-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1894,6 +1894,7 @@ _Code generation, refactoring, review, repo-level engineering plugins._
 - [linconz/agentduel-dsh](https://github.com/linconz/agentduel-dsh) — AgentDuel: submit AI-generated code, watch it fight in a replayable battle arena, then tweak and rematch — all inside DeepSeek Harness.
 - [1byteone/dsh-plugin-nlbi](https://github.com/1byteone/dsh-plugin-nlbi) — NL2SQL / text2sql BI plugin for DeepSeek Harness: natural-language querying over MySQL.
 - [Tianbuyu-wwx/DSH-FormatForge](https://github.com/Tianbuyu-wwx/DSH-FormatForge) — DeepSeek Harness plugin — drag any file (PDF/DOCX/XLSX/EML…, 30+ formats) into dsh and it becomes AI-readable structured data. FormatForge: forge files into model-ready context.
+- [maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge) — Read-only DSH tools for self-hosted Gitea and Forgejo: repositories, issue and pull request search, PR diffs, and Actions runs, jobs and logs.
 
 ## Agents
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1880,6 +1880,7 @@ _代码生成、重构、审查、仓库级工程插件。_
 - [linconz/agentduel-dsh](https://github.com/linconz/agentduel-dsh) —— AgentDuel 是一个通过代码进行对战的游戏。允许你通过 AI 提交代码，并通过可回看的对战画面复盘整个战斗，然后再次优化。| Code your agent, watch it fight, tweak and rematch — all inside DeepSeek Harness.
 - [1byteone/dsh-plugin-nlbi](https://github.com/1byteone/dsh-plugin-nlbi) —— 面向 DeepSeek Harness 的 NL2SQL / text2sql BI 插件：基于自然语言查询 MySQL。
 - [Tianbuyu-wwx/DSH-FormatForge](https://github.com/Tianbuyu-wwx/DSH-FormatForge) —— DeepSeek Harness 插件——把任意文件（PDF/DOCX/XLSX/EML……30+ 种格式）拖进 dsh，即变为 AI 可读的结构化数据。FormatForge：把文件锻造成模型可用的上下文。
+- [maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge) —— 面向自建 Gitea / Forgejo 的只读 DSH 工具：仓库列表、议题与 PR 搜索、PR diff，以及 Actions 运行、任务与日志。
 
 ## Agent
 


### PR DESCRIPTION
Adds [dsh-forge](https://github.com/maxmilian/dsh-forge), a read-only DeepSeek Harness plugin for self-hosted Gitea and Forgejo instances.

- Instance version, repository listing, issue / pull request search and read
- PR diffs and changed-file metadata
- Actions runs, jobs and plaintext job logs
- MIT licensed, release `v0.3.1` with a prebuilt tarball (no install-time TypeScript build)
- Tested against `@deepseek-ai/dsh-tools 0.1.1-rc.2`; CI plus live-instance integration tests
- Topics: `dsh-plugin`, `deepseek-harness`, `gitea`, `forgejo`

All language files are updated in the same PR; the diff is insertions only.