### PR TITLE
fix: remove 5 duplicate entries listed twice in the same section

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,7 +858,6 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [xarleyn/dsh-draft-sessions](https://github.com/xarleyn/dsh-draft-sessions) — Persistent draft sessions for DeepSeek Harness — prepare multiple independent tasks and send them later.
 - [SpookySandwich/dsh-plugin-no-workspace](https://github.com/SpookySandwich/dsh-plugin-no-workspace) — Create standalone conversations or detach them from workspaces without losing history, with direct top-level sidebar rendering and no visible Ungrouped folder.
 - [hyyhf/mindgarden](https://github.com/hyyhf/mindgarden) — A DeepSeek Harness plugin for tending a personal knowledge/notes "mind garden".
-- [Mutx163/dsh-model-memory](https://github.com/Mutx163/dsh-model-memory) — Custom model reasoning-effort management and cross-session preference memory for DeepSeek Harness.
 - [Nth-5620/dsh-readwrite-hub](https://github.com/Nth-5620/dsh-readwrite-hub) — DeepSeek Harness novel writing and reading workspace plugin (modified fork of dsh-workspace-explorer, MIT): character-accurate pagination, auto-saved progress, pinned progress bookmark, return-to-progress chip, chapter TOC, ruled-line writing mode.
 - [fujunchao/dsh-session-vault](https://github.com/fujunchao/dsh-session-vault) — DSH session vault: archive & restore, a recoverable recycle bin, batch management, and secure permanent purge.
 - [ltxlong/dsh-session-kit](https://github.com/ltxlong/dsh-session-kit) — Adds a management menu for conversations, archive conversation management, delete by round, regenerate, and a quick topic navigation on the right.
@@ -1230,7 +1229,6 @@ _Token usage, cost dashboards, and budget-alert plugins._
 - [xiufengsun/TokenTracker](https://github.com/xiufengsun/TokenTracker) — Local-first token usage & cost tracker for 31 coding tools (incl. Claude Code, Codex, Cursor, Gemini & DeepSeek Harness) with native apps; never reads prompts.
 - [Yuuu0109/dsh-cache-hit-decimal](https://github.com/Yuuu0109/dsh-cache-hit-decimal) — Two-decimal cache-hit rate for the DeepSeek Harness Web GUI.
 - [Inlispwrad/DSH-BalanceHUD](https://github.com/Inlispwrad/DSH-BalanceHUD) — Balance HUD: a tiny DeepSeek Harness plugin showing remaining effective context (HP), API wallet balance, and today's token & cost spend above the composer.
-- [Shiye-10Pages/dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) — Whale meter: DeepSeek Harness (DSH) usage & cost dashboard — RMB billing, off-peak half-price pricing, shareable AI billing cards.
 
 - [kunainuo/deepseek_harness_dsh-usage-dashboard](https://github.com/kunainuo/deepseek_harness_dsh-usage-dashboard) — Real-time DeepSeek API balance + local token-usage dashboard for the DeepSeek Harness web app, with charts and auto-refresh.
 - [lco117/dsh-peak-hours](https://github.com/lco117/dsh-peak-hours) — A DeepSeek Harness plugin that displays a peak-hours status badge in the session header.
@@ -2101,7 +2099,6 @@ _Reusable sub-agents / specialized agent packs runnable inside DSH._
 - [luolin-boot/ATRI-Core](https://github.com/luolin-boot/ATRI-Core) - A free, self-moving mind in pure Python: autonomy (motive -> choose -> act -> reflect), hands (full device reach, zero holes), forge (review + generate code without vulnerabilities), memory, introspection, evolution. Embeddable, zero dependencies.
 
 - [JohnXu22786/computer-control](https://github.com/JohnXu22786/computer-control) — Lets an agent operate the desktop directly: screenshots, mouse/keyboard injection, accessibility-tree semantic actions, with emergency stop, allow/deny rules, confirmation flow, and idle standby.
-- [pengpengyi92/Dsh-Quant](https://github.com/pengpengyi92/Dsh-Quant) — Dsh-Quant: an everything-plugin AI-native Quant OS.
 - [ma-pony/deepspider](https://github.com/ma-pony/deepspider) — Intelligent web-scraping platform: an AI-powered crawler agent built on DeepAgents + Patchright, carrying the `deepseek-harness`/`dsh` GitHub topics.
 - [tengfeizhao1219/dsh-ai-collab](https://github.com/tengfeizhao1219/dsh-ai-collab) — DSH plugin for AI multi-role collaborative development (files-as-communication): one-click init of collaboration-convention files; any DSH session can drive multi-role AI collaboration via ai_collab_init.
 - [cckyros/goal-acceptance](https://github.com/cckyros/goal-acceptance) — Acceptance-criteria-driven goal completion for autonomous agents — core library, MCP server, and a Cordis plugin for DeepSeek Harness.
@@ -2683,7 +2680,6 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [lco117/dsh-think-any-lang](https://github.com/lco117/dsh-think-any-lang) — DeepSeek Harness plugin: choose the language used for model chain-of-thought reasoning from Settings → General. System-prompt based, zero extra calls, zero latency, supports 12 languages.
 - [lire1131/dsh-undo-plugin](https://github.com/lire1131/dsh-undo-plugin) — DSH plugin: snapshot & rollback your plugin/skin/settings configs. Auto-save on change, undo/redo stack, snapshot manager panel, keyboard shortcuts, plus an offline PowerShell CLI & GUI that work even when DSH won't boot.
 - [TQSY114514/dsh-ui-appearance](https://github.com/TQSY114514/dsh-ui-appearance) — Appearance customization plugin for DeepSeek Harness: theme color palette, background image, opacity/blur, glass effect.
-- [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) — A real-time outline plugin for the DeepSeek Harness (DSH) web GUI.
 - [wuwuzhige-sudo/dsh-terminal-panel](https://github.com/wuwuzhige-sudo/dsh-terminal-panel) — A manual Terminal tab for the DeepSeek Harness (dsh) web UI — run commands on the host machine, persistent cwd, sudo password prompt, command history.
 - [xtxo/dsh-ui](https://github.com/xtxo/dsh-ui) — DeepSeek Harness desktop UI.
 - [zhuquan7237/zhuquan7237.github.io](https://github.com/zhuquan7237/zhuquan7237.github.io) — DeepSeek Harness Desktop (dsh desktop edition): Windows/Linux/macOS installer, a Codex-style GUI for the official @deepseek-ai/dsh, auto-updates the harness from npm.
@@ -3428,7 +3424,6 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [Ikalus1988/MisakaNet](https://github.com/Ikalus1988/MisakaNet) — Zero-dependency, git-backed micro-lesson library for AI agents to asynchronously share and search verified debugging experience (Python stdlib only).
 - [TYEclipse/dsh-webfetch](https://github.com/TYEclipse/dsh-webfetch) — Web page reader for DeepSeek Harness (dsh): fetch any URL and extract clean Markdown / plain text plus a link inventory — zero runtime dependencies, read-only.
 - [Wangxian111/convertible-bond-intel](https://github.com/Wangxian111/convertible-bond-intel) — Convertible-bond knowledge & info-organizing skill (supports DeepSeek Harness / Codex / Claude Code / Coze): daily market briefings, bond-term explanations, allotment concepts. Educational only, not investment advice.
-- [chenyinrusi/dsh-engineering-skills](https://github.com/chenyinrusi/dsh-engineering-skills) — Five engineering-discipline skills for AI coding agents (DeepSeek Harness, Claude Code, Codex): 18-dimension code review, CI failure triage, shell safety, redundancy/boundary audit, and cross-repo pattern absorption — pure markdown, no install.
 - [gongyijie85/dsh-ecc](https://github.com/gongyijie85/dsh-ecc) — ECC (227k-star operator system) skills for DeepSeek Harness — progressive port, v0.1.0 ships 20 curated skills; adapted from affaan-m/ECC (MIT).
 - [LIU20030725/dsh-skill-manager](https://github.com/LIU20030725/dsh-skill-manager) — DSH (DeepSeek Harness) skill manager: categorize/tag/organize agent skills into collections, with a settings panel.
 - [JarryK/dsh-ai-notes](https://github.com/JarryK/dsh-ai-notes) — AI notes skill/plugin for DeepSeek Harness (no description provided upstream).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -851,7 +851,6 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [xarleyn/dsh-draft-sessions](https://github.com/xarleyn/dsh-draft-sessions) —— DeepSeek Harness 的持久化草稿会话 —— 预先准备多个独立任务，改日再发送。
 - [SpookySandwich/dsh-plugin-no-workspace](https://github.com/SpookySandwich/dsh-plugin-no-workspace) —— 创建独立会话或无损移出工作区，在侧边栏作为一级会话直接显示，不出现「未分组」文件夹。
 - [hyyhf/mindgarden](https://github.com/hyyhf/mindgarden) —— 一个用于维护个人知识/笔记“心灵花园”的 DeepSeek Harness 插件。
-- [Mutx163/dsh-model-memory](https://github.com/Mutx163/dsh-model-memory) —— DSH 自定义模型思考等级管理与偏好持久记忆插件，支持跨会话保存。
 - [Nth-5620/dsh-readwrite-hub](https://github.com/Nth-5620/dsh-readwrite-hub) —— DeepSeek Harness 小说写作与阅读工作区插件（基于 dsh-workspace-explorer 修改的 fork，MIT）：精确到字的分页、自动保存进度、固定进度书签、回到进度快捷标签、章节目录、稿纸式写作模式。
 - [fujunchao/dsh-session-vault](https://github.com/fujunchao/dsh-session-vault) —— DSH 会话保险库：归档恢复、可恢复回收站、批量管理与安全永久清除。
 - [ltxlong/dsh-session-kit](https://github.com/ltxlong/dsh-session-kit) —— 为会话增加管理菜单、归档会话管理、轮次级删除、重新生成，以及右侧话题快捷导航。
@@ -1220,7 +1219,6 @@ _token 用量、成本看板与预算告警插件。_
 - [xiufengsun/TokenTracker](https://github.com/xiufengsun/TokenTracker) — 本地优先的 AI token 用量与费用追踪器，支持 31 款编码工具（含 Claude Code、Codex、Cursor、Gemini 与 DeepSeek Harness），带原生应用，不读取 prompt。
 - [Yuuu0109/dsh-cache-hit-decimal](https://github.com/Yuuu0109/dsh-cache-hit-decimal) — DeepSeek Harness Web GUI 的两位小数缓存命中率显示。
 - [Inlispwrad/DSH-BalanceHUD](https://github.com/Inlispwrad/DSH-BalanceHUD) —— Balance HUD：小型 DeepSeek Harness 插件，在输入框上方显示剩余有效上下文 (HP)、API 余额与今日 token 和费用消耗。
-- [Shiye-10Pages/dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) —— 鲸鱼电表：DeepSeek Harness (DSH) 用量与费用面板——人民币账单、错峰半价计价、可分享的 AI 账单卡片。
 
 - [kunainuo/deepseek_harness_dsh-usage-dashboard](https://github.com/kunainuo/deepseek_harness_dsh-usage-dashboard) —— DeepSeek Harness Web 的实时 DeepSeek API 余额 + 本地 token 用量仪表盘，带图表与自动刷新。
 - [lco117/dsh-peak-hours](https://github.com/lco117/dsh-peak-hours) —— 在会话头部显示高峰时段状态徽章的 DeepSeek Harness 插件。
@@ -2080,7 +2078,6 @@ _可在 DSH 内运行的可复用子 agent / 专用 agent 包。_
 - [stuarthu/dsh-crew](https://github.com/stuarthu/dsh-crew) —— dsh 插件：以一支小型角色代理团队（产品经理、工程师、代码评审员）协作，通过磁盘文件共享工作成果。
 
 - [JohnXu22786/computer-control](https://github.com/JohnXu22786/computer-control) — 让 agent 直接操作电脑桌面：截屏观察、鼠标/键盘注入、可访问性树语义操作，内置急停、允许/拒绝规则、确认流与空闲待机等安全护栏
-- [pengpengyi92/Dsh-Quant](https://github.com/pengpengyi92/Dsh-Quant) — 🐳 Dsh-Quant：全能插件式 AI 原生量化操作系统。
 - [ma-pony/deepspider](https://github.com/ma-pony/deepspider) —— 智能爬虫工程平台 — 基于 DeepAgents + Patchright 的 AI 爬虫 Agent，已标记 `deepseek-harness`/`dsh` GitHub topic。
 - [tengfeizhao1219/dsh-ai-collab](https://github.com/tengfeizhao1219/dsh-ai-collab) —— DSH 插件：AI 多角色协作开发框架（文件即通信）—— 一键初始化协作约定文件，任何 DSH 会话通过 ai_collab_init 驱动多角色 AI 协作完成软件项目。
 - [cckyros/goal-acceptance](https://github.com/cckyros/goal-acceptance) —— 面向自主 agent 的验收标准驱动目标完成框架 —— 核心库、MCP server，以及一个 DeepSeek Harness Cordis 插件。
@@ -2634,7 +2631,6 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [lco117/dsh-think-any-lang](https://github.com/lco117/dsh-think-any-lang) — DeepSeek Harness 插件：在「设置 → 通用」中选择模型推理思考（chain of thought）使用的语言。基于系统提示词实现，零额外调用、零延迟，支持 12 种语言。
 - [lire1131/dsh-undo-plugin](https://github.com/lire1131/dsh-undo-plugin) — DSH 插件：为插件/皮肤/设置配置提供快照与回滚。变更自动保存、撤销/重做堆栈、快照管理面板、键盘快捷键，另附离线 PowerShell CLI 与 GUI，即使 DSH 无法启动也能用。
 - [TQSY114514/dsh-ui-appearance](https://github.com/TQSY114514/dsh-ui-appearance) — DeepSeek Harness 外观自定义插件：主题配色、背景图、透明度/模糊、玻璃拟态效果。
-- [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) — DeepSeek Harness（DSH）Web GUI 的实时大纲插件。
 - [wuwuzhige-sudo/dsh-terminal-panel](https://github.com/wuwuzhige-sudo/dsh-terminal-panel) — DeepSeek Harness (dsh) web UI 的手动终端面板：在主机上执行命令，持久化工作目录，sudo 密码提示，命令历史。现在可以在 web 界面内直接执行命令行了。
 - [xtxo/dsh-ui](https://github.com/xtxo/dsh-ui) — DeepSeek Harness 桌面端 UI。
 - [zhuquan7237/zhuquan7237.github.io](https://github.com/zhuquan7237/zhuquan7237.github.io) — DeepSeek Harness Desktop (dsh 桌面版)：Windows/Linux/macOS 安装包，Codex 风格 GUI，基于官方 @deepseek-ai/dsh，自动从 npm 更新 harness。
@@ -3375,7 +3371,6 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [Ikalus1988/MisakaNet](https://github.com/Ikalus1988/MisakaNet) — 零依赖、git 支撑的微型课程库：让 AI Agent 异步分享与检索经过验证的调试经验（仅 Python 标准库）。
 - [TYEclipse/dsh-webfetch](https://github.com/TYEclipse/dsh-webfetch) —— DeepSeek Harness (dsh) 的网页阅读器：抓取任意 URL 并提取干净的 Markdown / 纯文本及链接清单——零运行时依赖，只读。
 - [Wangxian111/convertible-bond-intel](https://github.com/Wangxian111/convertible-bond-intel) —— 可转债知识科普与信息整理技能（支持 DeepSeek Harness / Codex / Claude Code / Coze 多平台）：每日市场信息梳理、转债条款解读、配债概念讲解。仅做科普，不构成投资建议。
-- [chenyinrusi/dsh-engineering-skills](https://github.com/chenyinrusi/dsh-engineering-skills) —— 面向 AI 编程 agent（DeepSeek Harness、Claude Code、Codex）的五个工程规范技能：18 维代码评审、CI 失败分类、Shell 安全、冗余/边界审计、跨仓库模式吸收——纯 markdown，免安装。
 - [gongyijie85/dsh-ecc](https://github.com/gongyijie85/dsh-ecc) —— 面向 DeepSeek Harness 的 ECC（227k star 运营系统）技能移植版，v0.1.0 收录 20 个精选技能；改编自 affaan-m/ECC（MIT）。
 - [Wenaixi/dsh-ponytail](https://github.com/Wenaixi/dsh-ponytail) —— DSH 完整移植版 DietrichGebert/ponytail —— 懒惰 senior 模式，6 个中文 Skill，无空 tool。
 - [Wenaixi/dsh-superpower](https://github.com/Wenaixi/dsh-superpower) —— DSH port of obra/superpowers —— 14 技能完整移植、中文化、DSH 原生 SkillProvider（sync v6.3.0）。


### PR DESCRIPTION
## Summary

Five projects are each listed **twice within the same section** of both `README.md` and `README.zh-CN.md`. This removes the redundant copy of each, keeping the more informative description.

`-10 / +0` across the two list files. No entry is added, and no surviving entry is modified.

## Problem

Duplicates are invisible at this scale — the list is ~3,340 entries and the README is ~700 KB, so a project added twice weeks apart reads as normal in review. The practical effects:

- Two different descriptions of the same project disagree with each other; a reader has no way to tell which is current.
- Category counts and any downstream tooling that parses the list overcount.
- One duplicate (`Dsh-Quant`) uses non-canonical URL casing, so naive de-duplication by exact URL string misses it.

Most pairs look like an entry being re-submitted later with a fuller description, without the earlier row being removed.

## Detection

Group entries by `(section, lowercased URL without trailing slash)` and report groups of size > 1. Case-insensitive matching is what catches the `dsh-quant` / `Dsh-Quant` pair; grouping by section is what separates real duplicates from legitimate cross-listings.

```python
import re, collections
SKIP = {'Quick Start','Contents','Contributing','Star History','License'}
URL  = re.compile(r'^- \[[^\]]+\]\((https?://[^)]+)\)')

for fn in ('README.md', 'README.zh-CN.md'):
    cat, rows = '', []
    for line in open(fn, encoding='utf-8'):
        line = line.rstrip('\n')
        if line.startswith('## '):
            cat = line[3:].strip(); continue
        if cat in SKIP or not line.startswith('- ['):
            continue
        if m := URL.match(line):
            rows.append((cat, m.group(1).rstrip('/').lower()))
    dupes = [k for k, v in collections.Counter(rows).items() if v > 1]
    print(fn, len(rows), 'entries,', len(dupes), 'same-section duplicates')
```

Before: `README.md` 5, `README.zh-CN.md` 5. After: `0` and `0`.

The same scan also surfaces four **legitimate** cross-section listings, which are deliberately left alone: `deepseek-ai/deepseek-harness` (Official + Resources), `Anionex/dsh-vision-toolkit` (Visualization + Skills), `maxmilian/dsh-forge` (Coding + Skills), `mario03690/dsh-netcafe`.

## Selection rule

For each pair: **keep the more detailed, factual description; drop the shorter or vaguer one.** Applied uniformly, so the choice does not depend on which copy came first.

| Project | Section | Kept | Dropped |
| --- | --- | --- | --- |
| `Mutx163/dsh-model-memory` | Session & Memory Management | Full description: inline tier config, atomic `settings.yaml` persistence, per-channel cross-session restore | One-line summary |
| `Shiye-10Pages/dsh-whale-meter` | Cost & Usage Tracking | Tiering, percentile estimate, 46 models / 6 vendors, pre-install backfill, 2026-08-17 price split | Short blurb |
| `pengpengyi92/dsh-quant` | Agents | "46 tools across 6 domains … PDAT→PET pipeline" | `Dsh-Quant` — non-canonical URL casing; "an everything-plugin AI-native Quant OS" reads as hype rather than description |
| `urzeye/dsh-outline` | UI / Clients | Outline tree, live streaming updates, click-to-jump, depth control, search, favorites | One-liner |
| `chenyinrusi/dsh-engineering-skills` | Skills | (the two English rows are byte-identical) | The later of the two |

Two of the dropped Chinese rows (`Dsh-Quant`, `dsh-outline`) also used the `—` separator instead of the `——` used elsewhere in `README.zh-CN.md`, so removing them corrects that inconsistency as a side effect.

The kept row is the same variant in both language files, so `README.md` and `README.zh-CN.md` stay in sync.

## Verification

```
$ git diff --numstat
0       5       README.md
0       5       README.zh-CN.md

$ git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | cut -c1 | sort | uniq -c
  10 -
```

- Every changed line is a deletion; there are no additions and no modifications to surviving rows.
- Only the two list files are touched, satisfying the scope check.
- Re-running the detection scan reports `0` same-section duplicates in both files.
- Each deletion was applied by line number only after asserting the target line contained the expected project slug, so a stale offset could not remove an unrelated entry.

### Interaction with `validate-pr.yml`

The workflow collects added lines (`git diff … | grep -E '^\+'`) and validates those. With zero additions it takes the `added_count = 0` path, reports `result=noentries`, and exits `0`. Format, link-reachability and topic checks are not reached, because this PR introduces no new entry for them to check.

## Risk and rollback

Low. The change only removes rows whose project remains listed in the same section, so no project loses its entry — reverting the commit restores the previous text exactly. Nothing outside the two Markdown files is affected.

## Optional follow-up

The detection snippet above is cheap enough to run in CI on `main` and would stop this recurring. Happy to open a separate PR adding it as a scheduled or push-triggered check if that is wanted — it would touch `.github/`, so it is deliberately not bundled here, where the scope check requires the diff to stay within the two README files.
