### PR TITLE
Auto-add 25 DSH plugins (20260826 scan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [KarlOfLaw/dsh-goal-mode-enhance](https://github.com/KarlOfLaw/dsh-goal-mode-enhance) — Visualized Goal mode for DeepSeek Harness: Goal bar / header entry / settings page (history + multi-session overview) / goal_overview model tool.
 - [Zn-Dk/dsh-session-explorer](https://github.com/Zn-Dk/dsh-session-explorer) — DSH Web out-of-tree plugin: message-level full-text search + timeline visualization for sessions.
 - [faye0526/dsh-backup-btn](https://github.com/faye0526/dsh-backup-btn) — One-click backup button for DeepSeek Harness (DSH): a floating button that backs up DSH data to a GitHub Gist.
+- [windrover/dsh-long-term-memory](https://github.com/windrover/dsh-long-term-memory) — Layered deterministic long-term memory for DeepSeek Harness: CJK-aware BM25 recall, JSONL storage, per-assembly context injection, write guards and threat scanning.
 
 ## Cost & Usage Tracking
 
@@ -1472,6 +1473,7 @@ _Bridges DSH into chat platforms and messaging channels._
 - [ZhuoSir/dsh-chatops](https://github.com/ZhuoSir/dsh-chatops) — IM bridge plugin for DeepSeek Harness: bind via WeChat QR to the official ClawBot bot (Tencent iLink protocol), or connect a self-built Feishu app, then list/switch/drive all DSH sessions from your phone's IM — sending text sends a prompt, finished tasks push results automatically, and risky operations push for approval (Feishu supports one-tap card-button approval). Multi-channel in parallel, official APIs only, zero public deployment.
 - [itsnone-liu/dsh-feishu](https://github.com/itsnone-liu/dsh-feishu) — Feishu/Lark bridge for DeepSeek Harness (dsh) — long-connection, card streaming, slash commands.
 - [TARS-snail/dsh-notify](https://github.com/TARS-snail/dsh-notify) — Desktop notifications for DeepSeek Harness sessions, only while you are away.
+- [lijian-ui/dsh-im-gateway](https://github.com/lijian-ui/dsh-im-gateway) — Multi-IM channel gateway plugin for DeepSeek Harness: DingTalk / QQ / personal WeChat, with QR-code binding and streaming replies.
 
 ## Plugin Marketplaces & Ecosystem
 - [aorucshiea/dsh-plugin-toggle](https://github.com/aorucshiea/dsh-plugin-toggle) — Hot-plug enable/disable switches for installed DSH plugins.
@@ -1596,6 +1598,8 @@ _Plugin marketplaces, install managers, indexes, and ecosystem tooling._
 - [LivXue/dsh-plugin-store](https://github.com/LivXue/dsh-plugin-store) — The plugin market for DeepSeek Harness: harvests dsh plugins from npm and publishes an auditable catalog.
 - [Muredsa/dsh-benchup](https://github.com/Muredsa/dsh-benchup) — Install with `npm i dsh-benchup`. Reproducible, profile-aware benchmarks for DeepSeek Harness — compare models, plugins, prompts, and agent strategies.
 - [keman-ai/dsh-skin-market](https://github.com/keman-ai/dsh-skin-market) — Skin market inside DSH: search and one-click install community skins from dsh.a2hmarket.ai, right from Settings.
+- [liyown/dshx](https://github.com/liyown/dshx) — Build, test, and ship typed DeepSeek Harness plugins — framework, scaffolding, and a verified community Hub.
+- [Morriaty-The-Murderer/dsh-plugin-abtest](https://github.com/Morriaty-The-Murderer/dsh-plugin-abtest) — Reproducible paired A/B experiments for DeepSeek Harness plugins, with isolated runners, auditable evidence, and deterministic promotion gates.
 
 ## Visualization
 
@@ -1986,6 +1990,8 @@ _Code generation, refactoring, review, repo-level engineering plugins._
 - [DM010727/dsh-cline](https://github.com/DM010727/dsh-cline) — Open-source DeepSeek Harness plugin — DSH (DeepSeek Harness) + Cline VS Code ecosystem fusion.
 - [HaoyueQin/dsh-diff-stat](https://github.com/HaoyueQin/dsh-diff-stat) — DeepSeek Harness web plugin: inline +N −M diff badges on edit/write tool rows and a per-turn file change summary card. Scroll-windowed diffs, PTC/code-dispatch fallback, undo — no git required.
 - [JanEickholt/dsh-inline-diff](https://github.com/JanEickholt/dsh-inline-diff) — See every file edit inline in the DeepSeek Harness chat — always-open side-by-side diffs for edit/write tool calls.
+- [jinsiyu/dsh-code-server-app](https://github.com/jinsiyu/dsh-code-server-app) — Package and install code-server (the web version of VS Code) as a plugin within DSH, for quick professional-grade file editing.
+- [meyaomiao/dsh-github-workbench](https://github.com/meyaomiao/dsh-github-workbench) — DSH plugin: use GitHub from the sidebar — repo tree + Issues/PR/Actions tabs, create Issues/PRs, comment, merge, and re-run CI; both a better-sidebar tab and a standalone panel.
 
 ## Agents
 
@@ -2261,6 +2267,9 @@ _Model Context Protocol servers that contribute tools / prompts / resources to D
 - [superagents-lab/dsh-s1](https://github.com/superagents-lab/dsh-s1) — Native s1 tools for the DeepSeek Harness (DSH): s1_search, s1_news, s1_crawl, s1_sitemap, s1_trending + bundled s1 skill.
 - [1321928757/dsh-mysql](https://github.com/1321928757/dsh-mysql) — MySQL connector plugin for DeepSeek Harness: configure connections in settings, switch per session from the composer, and expose mysql_query/mysql_tables/mysql_execute tools to every agent preset.
 - [aooyoo/dsh-web-search-ddg](https://github.com/aooyoo/dsh-web-search-ddg) — Zero-token DuckDuckGo search provider for the DeepSeek Harness (DSH) web seam — local headless browser, no API key, no model billing.
+- [BENZEMA216/wechat-archive-harness](https://github.com/BENZEMA216/wechat-archive-harness) — Privacy-first WeChat archive MCP plugin and Agent Skill for DeepSeek Harness, local-first and defaults to denying risky state.
+- [Casually/dsh-trae-api](https://github.com/Casually/dsh-trae-api) — Trae API integration plugin for DeepSeek Harness.
+- [NOirBRight/dsh-llm-cursor](https://github.com/NOirBRight/dsh-llm-cursor) — Cursor subscription login and chat for DeepSeek Harness.
 
 ## Orchestrators & Aggregators
 
@@ -3353,6 +3362,21 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [secyborg/dsh-command-rail](https://github.com/secyborg/dsh-command-rail) — DSH web plugin: a Codex-style command-history rail covering the WHOLE session.
 - [zptalk0221-cpu/dsh-remote-desktop](https://github.com/zptalk0221-cpu/dsh-remote-desktop) — Mobile remote-desktop plugin: brings a landscape phone shell and Chinese IME support to DeepSeek Harness.
 - [lzxcs/lag-trace-pro](https://github.com/lzxcs/lag-trace-pro) — DSH web UI performance recorder: auto-captures page jank (long animation frames, long tasks, frame freezes) with context snapshots, stored under ~/.dsh/perf/.
+- [chinazkk/dsh-task-panel](https://github.com/chinazkk/dsh-task-panel) — DSH web task panel for queued sub-agent execution, scheduled runs, auto review, acceptance, rework, and historical session context.
+- [ChuGe1206/dsh-platform](https://github.com/ChuGe1206/dsh-platform) — Tauri-based GUI platform for DeepSeek Harness (dsh).
+- [exoticknight/dsh-theme-eink-retro](https://github.com/exoticknight/dsh-theme-eink-retro) — A paper-and-ink client-side theme for DeepSeek Harness with Balanced and Immersive modes.
+- [HaoyueQin/deepseek-harness-desktop](https://github.com/HaoyueQin/deepseek-harness-desktop) — A desktop shell for DeepSeek Harness: wraps the official dsh web UI into a native-feeling, always-on desktop app.
+- [hi-fangj/dsh-models-radar](https://github.com/hi-fangj/dsh-models-radar) — Model capability radar plugin for the DeepSeek Harness Web GUI.
+- [keman-ai/dsh-skin-pack](https://github.com/keman-ai/dsh-skin-pack) — A full skin set for DeepSeek Harness: 28 themes in one repo, each independently installable.
+- [lansi-ai/dsh-desktop](https://github.com/lansi-ai/dsh-desktop) — Turns DeepSeek Harness into a true desktop app: an Electron main process embedding the Cordis Host (same kernel as the official Web build, zero porting), rendering the official Web UI release via a custom `file://` protocol + IPC bridge (no HTTP port exposed); all native desktop capabilities (tray, global hotkeys, system notifications, clipboard, autostart, protocol handlers, multi-window) are injected as host plugins, mirroring the official "everything is a plugin" architecture.
+- [mtaech/whale-nest](https://github.com/mtaech/whale-nest) — Tauri v2-based desktop client for DeepSeek Harness (dsh): runs dsh in the background and displays its Web UI in the frontend.
+- [oil-oil/dsh-theme](https://github.com/oil-oil/dsh-theme) — Live theme editor for DeepSeek Harness with curated palettes and typography controls.
+- [savageops/dsh-rich-questions](https://github.com/savageops/dsh-rich-questions) — Rich branching survey system for the DeepSeek Harness (DSH) Web GUI — an `ask_survey` tool with branch graphs, delayed hover insights, Mermaid diagrams, quick mode, and reroll/push/discuss actions.
+- [SuCriss/dsh-leekbox](https://github.com/SuCriss/dsh-leekbox) — LeekBox — an A-share (China stock market) watch assistant, as a DeepSeek Harness (DSH) web plugin.
+- [sundusk/dsh-yu-pet](https://github.com/sundusk/dsh-yu-pet) — Xiaoyu (小雨) — a DSH Web GUI floating desktop-pet plugin: frame-by-frame sprite animation, status that follows session activity, and drag-to-run behavior.
+- [vritser/dsh-emacs](https://github.com/vritser/dsh-emacs) — An Emacs client for DeepSeek Harness.
+- [WSL043/dsh-native-image-viewer](https://github.com/WSL043/dsh-native-image-viewer) — Native zoom, pan, download, gallery, and region-note image viewer for DeepSeek Harness.
+- [yu-wenchao/dsh-free-models-hub](https://github.com/yu-wenchao/dsh-free-models-hub) — Free-models leaderboard: a DeepSeek Harness community plugin adding a "Free Models Rank" panel to the DSH Web UI sidebar — paginated browsing, expandable API endpoint/model-name details with a "get a free API key" button, and one-click setup into Settings → Models → Custom Provider.
 
 ## Skills
 
@@ -3550,6 +3574,7 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [weshopai/weshop-skill-package](https://github.com/weshopai/weshop-skill-package) — Creative AI Skills for Codex, Claude Code, Cursor, Deepseek harness and any Agent Skills-compatible runtime.
 
 - [dshworks/howto-dsh](https://github.com/dshworks/howto-dsh) — Verified field notes for DeepSeek Harness (dsh): traps, skills, hooks, profiles. Every claim dated against a dsh version, with source paths to re-verify. Not affiliated with DeepSeek.
+- [Nay-1/dsh-skill-manage](https://github.com/Nay-1/dsh-skill-manage) — A settings-page plugin for managing DeepSeek Harness skills: graphical install/uninstall and enable/disable for both user-level and project-level skills.
 ## Resources
 
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) — Official source repo.  `⭐38238`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1139,6 +1139,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [KarlOfLaw/dsh-goal-mode-enhance](https://github.com/KarlOfLaw/dsh-goal-mode-enhance) —— 为 DeepSeek Harness 提供可视化 goal 模式：Goal 栏 / 头部入口 / 设置页（历史 + 多会话总览）/ goal_overview 模型工具。
 - [Zn-Dk/dsh-session-explorer](https://github.com/Zn-Dk/dsh-session-explorer) —— DSH Web 站外插件：消息级全文搜索 + 会话时间线可视化。
 - [faye0526/dsh-backup-btn](https://github.com/faye0526/dsh-backup-btn) —— DSH 一键备份按钮 —— 悬浮按钮将 DSH 数据备份到 GitHub Gist。
+- [windrover/dsh-long-term-memory](https://github.com/windrover/dsh-long-term-memory) —— 面向 DeepSeek Harness 的分层确定性长期记忆：支持中日韩文本的 BM25 检索、JSONL 存储、按装配注入上下文、写入防护与威胁扫描。
 
 ## 成本与用量统计
 
@@ -1465,6 +1466,7 @@ _把 DSH 桥接到各种聊天平台与消息通道。_
 - [ZhuoSir/dsh-chatops](https://github.com/ZhuoSir/dsh-chatops) —— dsh-chatops 是 DeepSeek Harness 的 IM 桥接插件：微信扫码绑定官方 ClawBot 机器人（腾讯 iLink 协议），或接入飞书自建应用，即可在手机 IM 里列出/切换/驱动所有 DSH 会话——发文字就是发 prompt，任务完成自动推送结果，危险操作推送审批（飞书支持卡片按钮一键批准）。多通道并行、纯官方接口、零公网部署。
 - [itsnone-liu/dsh-feishu](https://github.com/itsnone-liu/dsh-feishu) —— 面向 DeepSeek Harness (dsh) 的飞书/Lark 桥接插件 —— 长连接、卡片流式输出、斜杠命令。
 - [TARS-snail/dsh-notify](https://github.com/TARS-snail/dsh-notify) —— DeepSeek Harness 会话的桌面通知，仅在你不在时推送。
+- [lijian-ui/dsh-im-gateway](https://github.com/lijian-ui/dsh-im-gateway) —— 为 DeepSeek Harness 提供多 IM 通道接入的网关插件：钉钉 / QQ / 个人微信，支持扫码绑定与流式回复。
 
 ## 插件市场与生态
 
@@ -1587,6 +1589,8 @@ _插件市场、安装管理器、索引与生态工具。_
 - [LivXue/dsh-plugin-store](https://github.com/LivXue/dsh-plugin-store) —— DeepSeek Harness 的插件市场：从 npm 抓取 dsh 插件并发布可审计目录。
 - [Muredsa/dsh-benchup](https://github.com/Muredsa/dsh-benchup) —— `npm i dsh-benchup` 安装。面向 DeepSeek Harness 的可复现、感知 profile 的基准测试工具，比较模型、插件、提示词与 agent 策略。
 - [keman-ai/dsh-skin-market](https://github.com/keman-ai/dsh-skin-market) —— DSH 里的皮肤市场：在设置里搜索并一键安装 dsh.a2hmarket.ai 上的社区皮肤。
+- [liyown/dshx](https://github.com/liyown/dshx) —— 构建、测试并发布类型化的 DeepSeek Harness 插件——框架、脚手架，以及经过验证的社区 Hub。
+- [Morriaty-The-Murderer/dsh-plugin-abtest](https://github.com/Morriaty-The-Murderer/dsh-plugin-abtest) —— 面向 DeepSeek Harness 插件的可复现配对 A/B 实验：隔离运行器、可审计证据链，以及确定性的晋升门槛。
 
 ## 可视化
 
@@ -1973,6 +1977,8 @@ _代码生成、重构、审查、仓库级工程插件。_
 - [LJH-snow/dsh-tool-github](https://github.com/LJH-snow/dsh-tool-github) —— DeepSeek Harness 的 GitHub 工具插件（基于 Cordis 的 dsh-plugin）。
 - [LJH-snow/dsh-tool-sql](https://github.com/LJH-snow/dsh-tool-sql) —— DeepSeek Harness 的 SQL/数据库工具插件（基于 Cordis 的 dsh-plugin）。
 - [JanEickholt/dsh-inline-diff](https://github.com/JanEickholt/dsh-inline-diff) —— 在 DeepSeek Harness 对话中直接查看每次文件编辑——为 edit/write 工具调用提供始终展开的并排 diff。
+- [jinsiyu/dsh-code-server-app](https://github.com/jinsiyu/dsh-code-server-app) —— 将 code-server（VSCode 网页版）打包安装到 dsh 内的插件，快速实现专业的文件编辑。
+- [meyaomiao/dsh-github-workbench](https://github.com/meyaomiao/dsh-github-workbench) —— DSH 插件：在侧边栏使用 GitHub —— 仓库目录树 + Issues/PR/Actions 页签，支持建 Issue/PR、评论、合并、重跑 CI；better-sidebar 页签与独立面板双形态。
 
 ## Agent
 
@@ -2240,6 +2246,9 @@ _向 DSH 贡献工具 / prompt / 资源的 Model Context Protocol server。_
 - [superagents-lab/dsh-s1](https://github.com/superagents-lab/dsh-s1) —— 面向 DeepSeek Harness (DSH) 的原生 s1 工具集：s1_search、s1_news、s1_crawl、s1_sitemap、s1_trending，附带 s1 skill。
 - [1321928757/dsh-mysql](https://github.com/1321928757/dsh-mysql) —— DeepSeek Harness 的 MySQL 连接插件：在设置中配置连接、从编写器按会话切换，向每个 agent preset 暴露 mysql_query/mysql_tables/mysql_execute 工具。
 - [aooyoo/dsh-web-search-ddg](https://github.com/aooyoo/dsh-web-search-ddg) —— DeepSeek Harness (DSH) web 接口的零 token DuckDuckGo 搜索提供商 —— 本地无头浏览器，无需 API key，不产生模型计费。
+- [BENZEMA216/wechat-archive-harness](https://github.com/BENZEMA216/wechat-archive-harness) —— 面向 DeepSeek Harness 的隐私优先微信归档 MCP 插件和 Agent Skill：本地优先、默认拒绝危险状态。
+- [Casually/dsh-trae-api](https://github.com/Casually/dsh-trae-api) —— 为 DeepSeek Harness 提供 Trae API 接入的插件。
+- [NOirBRight/dsh-llm-cursor](https://github.com/NOirBRight/dsh-llm-cursor) —— 为 DeepSeek Harness 提供 Cursor 订阅登录与对话能力。
 
 ## 编排器与聚合器
 
@@ -3306,6 +3315,21 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [secyborg/dsh-command-rail](https://github.com/secyborg/dsh-command-rail) —— DSH web 插件：覆盖整个会话的 Codex 风格命令历史导轨。
 - [zptalk0221-cpu/dsh-remote-desktop](https://github.com/zptalk0221-cpu/dsh-remote-desktop) —— 远程桌面移动化插件：为 DeepSeek Harness 提供手机横屏外壳与中文输入法。
 - [lzxcs/lag-trace-pro](https://github.com/lzxcs/lag-trace-pro) —— DSH web UI 性能录制工具：自动捕捉页面卡顿（长动画帧、长任务、卡频）并附带上下文快照，存在 ~/.dsh/perf/ 下。
+- [chinazkk/dsh-task-panel](https://github.com/chinazkk/dsh-task-panel) —— DSH Web 任务面板：支持排队子代理执行、定时任务、自动审查、验收、返工与历史会话上下文。
+- [ChuGe1206/dsh-platform](https://github.com/ChuGe1206/dsh-platform) —— 基于 Tauri 的 DeepSeek Harness (dsh) 图形化平台。
+- [exoticknight/dsh-theme-eink-retro](https://github.com/exoticknight/dsh-theme-eink-retro) —— 面向 DeepSeek Harness 的纸墨风客户端主题，提供平衡与沉浸两种模式。
+- [HaoyueQin/deepseek-harness-desktop](https://github.com/HaoyueQin/deepseek-harness-desktop) —— 为 DeepSeek Harness（DeepSeek 开源的可插拔 AI Agent harness）打造的桌面应用壳，把官方 dsh web 界面包装成原生质感、常驻后台的桌面应用。
+- [hi-fangj/dsh-models-radar](https://github.com/hi-fangj/dsh-models-radar) —— 为 DeepSeek Harness Web GUI 提供模型能力雷达图的插件。
+- [keman-ai/dsh-skin-pack](https://github.com/keman-ai/dsh-skin-pack) —— 给 DeepSeek Harness 的一整套皮肤：28 套主题，一个仓库，各自独立安装。
+- [lansi-ai/dsh-desktop](https://github.com/lansi-ai/dsh-desktop) —— 把 DeepSeek Harness 做成一个真正的桌面应用：Electron 主进程内嵌 Cordis Host（与官方 Web 版同内核、零移植），渲染进程加载官方 Web UI 发行物（file:///自定义协议 + IPC 桥接，不开放 HTTP 端口），所有桌面原生能力（托盘、全局热键、系统通知、剪贴板、开机自启、协议唤起、多窗口）以 host 插件形态注入运行时，与官方「一切皆插件」的架构同构。
+- [mtaech/whale-nest](https://github.com/mtaech/whale-nest) —— 基于 Tauri v2 的 DeepSeek Harness (dsh) 桌面客户端：后台常驻运行 dsh，前端展示其 Web UI。
+- [oil-oil/dsh-theme](https://github.com/oil-oil/dsh-theme) —— 面向 DeepSeek Harness 的实时主题编辑器，提供精选配色方案与字体排版控制。
+- [savageops/dsh-rich-questions](https://github.com/savageops/dsh-rich-questions) —— 面向 DeepSeek Harness (DSH) Web GUI 的富分支问卷系统 —— `ask_survey` 工具支持分支图、延迟悬浮提示、Mermaid 图表、快速模式及重掷/推送/讨论操作。
+- [SuCriss/dsh-leekbox](https://github.com/SuCriss/dsh-leekbox) —— 韭菜盒子 LeekBox — A股看盘助手 · DeepSeek Harness (DSH) web 插件。
+- [sundusk/dsh-yu-pet](https://github.com/sundusk/dsh-yu-pet) —— 小雨（Xiaoyu）· DSH Web GUI 悬浮桌宠插件：精灵图逐帧动画、状态跟随会话活动、拖拽奔跑。
+- [vritser/dsh-emacs](https://github.com/vritser/dsh-emacs) —— 面向 DeepSeek Harness 的 Emacs 客户端。
+- [WSL043/dsh-native-image-viewer](https://github.com/WSL043/dsh-native-image-viewer) —— 为 DeepSeek Harness 提供的原生图片查看器：支持缩放、平移、下载、图库浏览及局部标注。
+- [yu-wenchao/dsh-free-models-hub](https://github.com/yu-wenchao/dsh-free-models-hub) —— 免费模型排行榜 · DeepSeek Harness 社区插件，在 DeepSeek Harness (DSH) Web UI 左侧边栏提供「免费模型榜」：分页浏览（每页 10 条、页码窗口、首页/末页）、点击标题展开 API 调用地址 / 模型名称 /【点击这里申请免费密钥key】按钮，并支持一键配置到 设置 → 模型 → 自定义提供方 —— 用户只需自行粘贴免费 API Key。
 
 ## Skill
 
@@ -3493,6 +3517,7 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [weshopai/weshop-skill-package](https://github.com/weshopai/weshop-skill-package) —— 面向 Codex、Claude Code、Cursor、Deepseek harness 以及任何兼容 Agent Skills 的运行时的创意 AI 技能包。
 
 - [dshworks/howto-dsh](https://github.com/dshworks/howto-dsh) —— DeepSeek Harness (dsh) 的经验证实地笔记：陷阱、skill、hook、profile。每条结论均标注对应的 dsh 版本，并附源码路径供复核。与 DeepSeek 官方无关联。
+- [Nay-1/dsh-skill-manage](https://github.com/Nay-1/dsh-skill-manage) —— DeepSeek Harness 技能管理设置页插件：图形化管理用户级/项目级技能的安装、卸载与调用启停。
 ## 资源
 
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) —— 官方源码仓库。  `⭐38238`


### PR DESCRIPTION
自动扫描收录：新增 25 条社区 DSH 插件（去重后）。仅改 README.md / README.zh-CN.md。由每日扫描自动化生成，PR 巡检会自动核验链接真实性与格式后合并。