### PR TITLE
Add zhengjy01/dsh-task-dispatcher (TickTick daily task dispatcher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2385,6 +2385,7 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [chumingjun/harness-one](https://github.com/chumingjun/harness-one) — Visual AI workflow orchestrator for DeepSeek Harness (dsh): multi-agent DAGs, live execution, recovery, and Feishu integration.
 - [yjh051108/dsh-routing-suite](https://github.com/yjh051108/dsh-routing-suite) — dsh-routing-suite — injector + router-standard kit: install the runtime injector first, then the task-aware reasoning-mode router preset (measured P1-P23).
 - [BigBlueBaby/codex2dsh](https://github.com/BigBlueBaby/codex2dsh) — One-click, fully visual migration of Codex (OpenAI Codex CLI / Desktop) MCP servers, skills, global config, and memory into DeepSeek Harness (DSH) — no command line needed.
+- [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) — TickTick (滴答清单) daily task dispatcher for DeepSeek Harness: interval-based pulls of today's due tasks with change-aware flomo + macOS notifications, optional auto-execute (one headless DSH session per task), worker workspace selection, a dispatcher_report flomo summary tool, and a web task board.
 
 - [ChanceFlow/deepseek-harness-app](https://github.com/ChanceFlow/deepseek-harness-app) — Flutter client for DeepSeek Harness (dsh): chat, workspaces, models, goals and subagents on Android — talks to an unmodified dsh web backend.
 - [HenryHwong/dsh-ui-turn-rail](https://github.com/HenryHwong/dsh-ui-turn-rail) — Turn progress rail plugin for the DeepSeek Harness Web GUI (dsh-plugin).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2288,6 +2288,7 @@ _多步 / 多 agent 调度器与输出聚合器。_
 - [superslash-rico/dsh-plugin-slashx-gateway](https://github.com/superslash-rico/dsh-plugin-slashx-gateway) —— SlashX 请求/响应/富媒体/异步回调与完整 token 计量的 DeepSeek Harness host 插件包。
 - [Uddoo/dsh-dashboard](https://github.com/Uddoo/dsh-dashboard) —— 兼容 Symphony 的 Linear issue 编排器与 DeepSeek Harness 原生运维仪表盘。
 - [writeCasually/deepseek-harness-plugins](https://github.com/writeCasually/deepseek-harness-plugins) — deepseek harness plugins view。
+- [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) —— 滴答清单任务派发器：按间隔拉取今天到期任务（有变化才通知 flomo+macOS），可选自动执行（每任务一个 headless 会话）、执行会话工作区选择、dispatcher_report flomo 汇总工具与 Web 任务看板。
 
 - [lileikeji/dsh-crosstalk](https://github.com/lileikeji/dsh-crosstalk) —— dsh-crosstalk：DSH 跨会话消息（Claude Code 风格）+ 事件驱动的自动协作协调。
 - [omdsh-dev/dsh-cron](https://github.com/omdsh-dev/dsh-cron) —— DeepSeek Harness 定时任务（cron）：模型与人都可调度的任务，可向 agent 会话触发 followup/inject。


### PR DESCRIPTION
Add **dsh-task-dispatcher** under **Orchestrators & Aggregators** (both README.md and README.zh-CN.md).

**dsh-task-dispatcher** — TickTick (滴答清单) daily task dispatcher for DeepSeek Harness:
- interval-based pulls of today's due tasks from the 5️⃣AI list
- change-aware flomo + macOS notifications
- optional auto-execute (one headless DSH session per task)
- worker workspace selection (which DSH workspace the produced sessions belong to)
- dispatcher_report flomo summary tool
- web task board

npm: dsh-task-dispatcher@0.1.0 · topics: dsh-plugin / deepseek-harness / ticktick