### PR TITLE
Auto-add 18 DSH plugins (20260827 scan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ _DSH's core composition mechanism: a **profile** stacks bundle patch layers, the
 - [yongshuai0314/dsh-i-have-adhd](https://github.com/yongshuai0314/dsh-i-have-adhd) — ADHD-friendly output shaping for DeepSeek Harness: one system-prompt section with adhd_on/adhd_off/adhd_status tools, persisted across restarts. Inspired by ayghri/i-have-adhd (MIT).
 - [jilian-dsh/dsh-rule-engine](https://github.com/jilian-dsh/dsh-rule-engine) — DSH rule-engine v3: treats `~/.dsh/AGENTS.md` as the single source of truth, auto-parses rule elements and enforcement levels, and enforces user rules via tool guards + text detection + timing checks + an audit ledger — rules stay dynamic, no plugin rewrite needed when they change.
 - [sakka6868/dsh-prompt-optimize-plugin](https://github.com/sakka6868/dsh-prompt-optimize-plugin) — "Prompt optimize" button for the DeepSeek Harness composer: one click rewrites a vague prompt into something clear, specific, and actionable, IDE-smart-suggestion style.
+- [savageops/dsh-rich-context](https://github.com/savageops/dsh-rich-context) — Agent instruction manager for DSH — edit and template the AGENTS.md files the harness actually reads (global + per-workspace).
 
 ## Harnesses & Runtimes
 
@@ -718,6 +719,10 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [XucroYuri/dsh-opencode-bridge](https://github.com/XucroYuri/dsh-opencode-bridge) — Experimental bridge to use OpenCode as a model provider from DeepSeek Harness.
 - [XucroYuri/dsh-opencode-sync](https://github.com/XucroYuri/dsh-opencode-sync) — Sync OpenCode provider configurations, credentials, and model metadata into DeepSeek Harness.
 - [XucroYuri/dsh-provider-catalog](https://github.com/XucroYuri/dsh-provider-catalog) — Maintain a local model catalog from OpenCode metadata for DeepSeek Harness.
+- [Gildra-Foundation/dsh](https://github.com/Gildra-Foundation/dsh) — Gildra DSH — desktop and server DeepSeek Harness kit with agents, MCP, automation, CodeGraph and SSH workflows.
+- [openllmsh/dsh](https://github.com/openllmsh/dsh) — DeepSeek Harness (dsh) bundle: route the harness through OpenLLM (OpenAI-compatible) + register the OpenLLM MCP, with CLI/daemon onboarding.
+- [sd1g1/dsh-opencode-go-models](https://github.com/sd1g1/dsh-opencode-go-models) — Fills out DSH's OpenCode Go model catalog.
+- [See-Sol-Lab/DeepCode](https://github.com/See-Sol-Lab/DeepCode) — Use it like Codex. Inspect it like a lab. Extend it like Harness.
 
 ## Security & Permissions
 
@@ -860,6 +865,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [Jensen-Yao/dsh-model-palette](https://github.com/Jensen-Yao/dsh-model-palette) — Global provider-aware model command palette and optional OpenRouter media tools for DeepSeek Harness.
 - [LucienLL/dsh-plugin-proxy](https://github.com/LucienLL/dsh-plugin-proxy) — Global proxy for DeepSeek Harness: route agent tools, model requests and web fetches through the Windows system proxy or a custom proxy with one persistent toggle and agent-visible status.
 - [LXFLGH/dsh-deepseek-relay](https://github.com/LXFLGH/dsh-deepseek-relay) — DeepSeek relay station adapter for deepseek-harness with reasoning-effort control.
+- [dongsheng123132/dsh-credential-retirement-proof](https://github.com/dongsheng123132/dsh-credential-retirement-proof) — Evidence-only DSH plugin for credential retirement settlement.
 
 ## Session & Memory Management
 
@@ -1167,6 +1173,9 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [navid-kianfar/dsh-tasks-manager](https://github.com/navid-kianfar/dsh-tasks-manager) — DeepSeek Harness plugin: a project task board kept with the project as a queryable SQLite file, with a kanban/list view in the Web Client, model-facing task tools, and cards you can dispatch to the agent as background jobs.
 - [Ranz-Feng/dsh-web-import](https://github.com/Ranz-Feng/dsh-web-import) — Import DeepSeek Web (chat.deepseek.com) chat history into DeepSeek Harness as resumable, workspace-grouped sessions with original titles preserved.
 - [TuringCorp-net/mosaic-memory-compress](https://github.com/TuringCorp-net/mosaic-memory-compress) — Stateless dialogue compression that mimics human memory. LLM conversations stay bounded forever — no session management, no context overflow.
+- [Ryu6Zero/dsh-hindsight](https://github.com/Ryu6Zero/dsh-hindsight) — 🧠 Cross-session memory for DeepSeek Harness backed by Hindsight. Self-contained dsh-plugin: /hindsight commands + hindsight_recall/remember/status/list/forget agent tools. Lightweight, no dsh-mnemon, no orchestrator.
+- [wicm84266964/dsh-minimal-mode-compaction](https://github.com/wicm84266964/dsh-minimal-mode-compaction) — Adds automatic context compaction, /compact, /context, and proactive model-driven compaction to DeepSeek Harness Minimal Mode, fixing its inability to sustain long tasks.
+- [jermaine123123/agent-context-editor](https://github.com/jermaine123123/agent-context-editor) — Cross-agent plugin for manually excluding and editing AI conversation context, with search, filtering, hide/restore, undo, and original Session preservation.
 
 ## Cost & Usage Tracking
 
@@ -2305,6 +2314,9 @@ _Model Context Protocol servers that contribute tools / prompts / resources to D
 - [Casually/dsh-trae-api](https://github.com/Casually/dsh-trae-api) — Trae API integration plugin for DeepSeek Harness.
 - [NOirBRight/dsh-llm-cursor](https://github.com/NOirBRight/dsh-llm-cursor) — Cursor subscription login and chat for DeepSeek Harness.
 - [TheBestCo/bestprice-mcp](https://github.com/TheBestCo/bestprice-mcp) — Official BestPrice MCP extension for product search, offer comparison, and price history.
+- [maxmilian/dsh-grafana-query](https://github.com/maxmilian/dsh-grafana-query) — Read-only Grafana metrics and alert tools for DeepSeek Harness (PromQL via datasource proxy).
+- [maxmilian/dsh-odoo](https://github.com/maxmilian/dsh-odoo) — Read-only Odoo tools for DeepSeek Harness, with an opt-in restricted draft-create tool.
+- [maxmilian/dsh-sentry](https://github.com/maxmilian/dsh-sentry) — Read-only Sentry issue and event tools for DeepSeek Harness.
 
 ## Orchestrators & Aggregators
 
@@ -2417,6 +2429,7 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [riesbri/dshline](https://github.com/riesbri/dshline) — The terminal-native frontend for the DeepSeek Harness plugin ecosystem.
 - [fiultyy/maestro-preset](https://github.com/fiultyy/maestro-preset) — Multi-agent orchestration preset for the DeepSeek Harness (DSH): cross-plane supervisor over Orca / dais (ex-zap) / DSH sessions — durable callback bridge (file+HTTP), fleet admission, SQLite ledger, flow compiler. Zero npm deps.
 - [HarnessRouter/harnessrouter](https://github.com/HarnessRouter/harnessrouter) — HarnessRouter Community Edition: self-hosted, Apache-2.0 unified interface for agent harnesses. Run Codex, Claude Code, Hermes, PI, DSH, and more through one API, with sessions, streaming, files, cancellation, and failure handling. Implements the Unified Harness Protocol (UHP), an open standard.
+- [Punky971210/dsh-punky-swarm](https://github.com/Punky971210/dsh-punky-swarm) — Engine-enforced guardrails for DeepSeek Harness agent swarms: quality gates reject half-done work, crash-safe checkpoints resume in place — keeps AI teams from breaking, not just running.
 
 ## UI / Clients
 - [776138506/pinpoint](https://github.com/776138506/pinpoint) — Point-and-annotate on any webpage, then send the screenshot plus structured text straight into a DSH session (DSH plugin + browser extension).
@@ -3421,6 +3434,9 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [XucroYuri/dsh-llm-oauth-ui](https://github.com/XucroYuri/dsh-llm-oauth-ui) — OAuth login status and future Web UI support for DeepSeek Harness.
 - [Che-Year/dsh-pet-lulu](https://github.com/Che-Year/dsh-pet-lulu) — A cute terminal and web pet plugin for DeepSeek Harness (dsh), using assets from lulu and capybara projects.
 - [mldhao/dsh-blue-archive-shiroko](https://github.com/mldhao/dsh-blue-archive-shiroko) — Blue Archive-inspired DSH theme with a Shiroko desktop companion, Codex-style reply bubbles, petting effects, and completion chime.
+- [Icather/dsh-clean-desktop-shell](https://github.com/Icather/dsh-clean-desktop-shell) — Clean desktop shell for DSH: one-click launch like a normal app, live backend monitoring with quick tray start/stop, zero visual changes.
+- [jkamkk/dsh-liquid-glass-input](https://github.com/jkamkk/dsh-liquid-glass-input) — Liquid Glass input card for the DSH web GUI: kube.io SVG refraction with coupled-spring press animation.
+- [NeoXider/neoxider-agent-deck](https://github.com/NeoXider/neoxider-agent-deck) — Animated desktop companion for DeepSeek Harness — live agent deck, mini-chat, streaming replies, model routing, context pressure and native commands, in a widget that docks to your screen edge.
 
 ## Skills
 
@@ -3622,6 +3638,8 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [fishzjp/qa-skills](https://github.com/fishzjp/qa-skills) — Make AI work like a senior QA engineer: a full-lifecycle QA Agent Skills framework — methodology + 10 skills + a reproducible benchmark (usable with Claude Code and other agents).
 - [nullptr-DZF/dsh-academic-research-skills](https://github.com/nullptr-DZF/dsh-academic-research-skills) — Academic-research skill pack for DeepSeek Harness (deepseek-harness-plugin, dsh-plugin).
 - [suyukun/dsh-tech-selection](https://github.com/suyukun/dsh-tech-selection) — Stop letting your AI guess — a research protocol for tech decisions that any AI agent (DSH/Claude/Cursor/Codex) can follow: quantified requirements, T1-T6 source tiers, quality gates, traceable verdicts.
+- [Kenerlee/dsh-moments-aieo](https://github.com/Kenerlee/dsh-moments-aieo) — AIEO (GEO/AEO) delivery method as a DeepSeek Harness bundle: five moments-aieo-* skills over a shared question library.
+- [kingselyjoe/xhs-chaijie-dsh](https://github.com/kingselyjoe/xhs-chaijie-dsh) — Native DSH skill for deep breakdowns of Xiaohongshu (RED) accounts and competitors: real cover-image audits, viral-asset reuse, and visualized HTML reports.
 ## Resources
 
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) — Official source repo.  `⭐38238`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -129,6 +129,7 @@ _DSH 的核心组合机制：一个 **profile** 叠加各 bundle 的 patch 层�
 - [yongshuai0314/dsh-i-have-adhd](https://github.com/yongshuai0314/dsh-i-have-adhd) —— 面向 DeepSeek Harness 的 ADHD 友好输出整形插件：一段系统提示 + adhd_on/adhd_off/adhd_status 工具，跨重启持久化；灵感来自 ayghri/i-have-adhd（MIT）。
 - [jilian-dsh/dsh-rule-engine](https://github.com/jilian-dsh/dsh-rule-engine) —— DSH 规则执行引擎 v3 的插件实现：把 `~/.dsh/AGENTS.md` 当作唯一真相源，自动解析规则四要素与执行等级，再通过工具守卫 + 文本检测 + 时序检查 + 审计台账执行用户规则，规则增删改后无需重写插件。
 - [sakka6868/dsh-prompt-optimize-plugin](https://github.com/sakka6868/dsh-prompt-optimize-plugin) —— DeepSeek Harness 输入栏「提示词优化」插件——一键把模糊的提示词改写成清晰、具体、可执行，像 IDE 里的智能提示一样顺手。
+- [savageops/dsh-rich-context](https://github.com/savageops/dsh-rich-context) —— DSH 的 agent 指令管理工具——编辑和模板化 harness 实际读取的 AGENTS.md 文件（全局 + 每工作区）。
 
 ## Harness 与运行时
 
@@ -711,6 +712,10 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [XucroYuri/dsh-opencode-bridge](https://github.com/XucroYuri/dsh-opencode-bridge) —— 实验性桥接插件，让 OpenCode 作为 DeepSeek Harness 的模型提供方使用。
 - [XucroYuri/dsh-opencode-sync](https://github.com/XucroYuri/dsh-opencode-sync) —— 将 OpenCode 提供方配置、凭据与模型元数据同步到 DeepSeek Harness。
 - [XucroYuri/dsh-provider-catalog](https://github.com/XucroYuri/dsh-provider-catalog) —— 基于 OpenCode 元数据为 DeepSeek Harness 维护本地模型目录。
+- [Gildra-Foundation/dsh](https://github.com/Gildra-Foundation/dsh) —— Gildra DSH —— 集成 agent、MCP、自动化、CodeGraph 以及 SSH 工作流的桌面与服务器 DeepSeek Harness 套件。
+- [openllmsh/dsh](https://github.com/openllmsh/dsh) —— DeepSeek Harness (dsh) 套件：通过 OpenLLM（OpenAI 兼容）路由 harness ＋注册 OpenLLM MCP，带 CLI/守护进程引导。
+- [sd1g1/dsh-opencode-go-models](https://github.com/sd1g1/dsh-opencode-go-models) —— 补齐 DSH 的 OpenCode Go 模型目录。
+- [See-Sol-Lab/DeepCode](https://github.com/See-Sol-Lab/DeepCode) —— 用法像 Codex，实验室式检阀，扩展方式像 Harness。
 
 ## 安全与权限
 
@@ -856,6 +861,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 - [Jensen-Yao/dsh-model-palette](https://github.com/Jensen-Yao/dsh-model-palette) —— 面向 DeepSeek Harness 的全局、感知提供商的模型命令面板，可选集成 OpenRouter 媒体工具。
 - [LucienLL/dsh-plugin-proxy](https://github.com/LucienLL/dsh-plugin-proxy) —— DeepSeek Harness 的全局代理插件：将 agent 工具、模型请求与网络请求路由到 Windows 系统代理或自定义代理，一个持久化开关加 agent 可见的状态提示。
 - [LXFLGH/dsh-deepseek-relay](https://github.com/LXFLGH/dsh-deepseek-relay) —— 面向 deepseek-harness 的 DeepSeek 中转站适配器，支持 reasoning-effort 控制。
+- [dongsheng123132/dsh-credential-retirement-proof](https://github.com/dongsheng123132/dsh-credential-retirement-proof) —— 仅提供审计证据的 DSH 插件，用于凭据退役结算。
 
 ## 会话与记忆管理
 
@@ -1162,6 +1168,9 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [navid-kianfar/dsh-tasks-manager](https://github.com/navid-kianfar/dsh-tasks-manager) —— DeepSeek Harness 插件：项目任务板以可查询的 SQLite 文件与项目一并保存，Web 客户端提供看板/列表视图，面向模型的任务工具，卡片可下发给 agent 作为后台任务。
 - [Ranz-Feng/dsh-web-import](https://github.com/Ranz-Feng/dsh-web-import) —— 将 DeepSeek Web（chat.deepseek.com）聊天记录导入 DeepSeek Harness，保留原标题，按工作区分组为可恢复会话。
 - [TuringCorp-net/mosaic-memory-compress](https://github.com/TuringCorp-net/mosaic-memory-compress) —— 模拟人类记忆的无状态对话压缩：LLM 对话永远保持可控规模——无需会话管理，无上下文溢出。
+- [Ryu6Zero/dsh-hindsight](https://github.com/Ryu6Zero/dsh-hindsight) —— 🧠 基于 Hindsight 为 DeepSeek Harness 提供跨会话记忆。自包含 dsh 插件：/hindsight 命令 + hindsight_recall/remember/status/list/forget 代理工具。轻量，无需 dsh-mnemon，无需编排器。
+- [wicm84266964/dsh-minimal-mode-compaction](https://github.com/wicm84266964/dsh-minimal-mode-compaction) —— 为 DeepSeek Harness 极简模式新增自动上下文压缩、/compact、/context 和模型主动压缩，解决极简模式下长任务无法持续工作的问题。
+- [jermaine123123/agent-context-editor](https://github.com/jermaine123123/agent-context-editor) —— 跨 agent 插件，可手动排除和编辑 AI 对话上下文，支持搜索、过滤、隐藏/恢复、撤销以及原始 Session 保留。
 
 ## 成本与用量统计
 
@@ -2284,6 +2293,9 @@ _向 DSH 贡献工具 / prompt / 资源的 Model Context Protocol server。_
 - [Casually/dsh-trae-api](https://github.com/Casually/dsh-trae-api) —— 为 DeepSeek Harness 提供 Trae API 接入的插件。
 - [NOirBRight/dsh-llm-cursor](https://github.com/NOirBRight/dsh-llm-cursor) —— 为 DeepSeek Harness 提供 Cursor 订阅登录与对话能力。
 - [TheBestCo/bestprice-mcp](https://github.com/TheBestCo/bestprice-mcp) —— BestPrice 官方 MCP 扩展，提供商品搜索、报价对比与历史价格。
+- [maxmilian/dsh-grafana-query](https://github.com/maxmilian/dsh-grafana-query) —— 为 DeepSeek Harness 提供只读的 Grafana 指标与告警工具（通过 datasource proxy 的 PromQL）。
+- [maxmilian/dsh-odoo](https://github.com/maxmilian/dsh-odoo) —— 为 DeepSeek Harness 提供只读的 Odoo 工具，带可选启用的限制草稿创建工具。
+- [maxmilian/dsh-sentry](https://github.com/maxmilian/dsh-sentry) —— 为 DeepSeek Harness 提供只读的 Sentry 问题与事件工具。
 
 ## 编排器与聚合器
 
@@ -2397,6 +2409,7 @@ _多步 / 多 agent 调度器与输出聚合器。_
 - [riesbri/dshline](https://github.com/riesbri/dshline) —— DeepSeek Harness 插件生态的终端原生前端。
 - [fiultyy/maestro-preset](https://github.com/fiultyy/maestro-preset) — DeepSeek Harness (DSH) 多智能体编排 preset：跨平面统管 Orca / dais（原 zap）/ DSH 会话 —— 持久回调桥接（文件+HTTP）、集群准入、SQLite 台账、流程编译器，零 npm 依赖。
 - [HarnessRouter/harnessrouter](https://github.com/HarnessRouter/harnessrouter) —— HarnessRouter 社区版：自部署、Apache-2.0 开源的 agent harness 统一接口。通过一个 API 运行 Codex、Claude Code、Hermes、PI、DSH 等，支持会话、流式输出、文件、取消与失败处理。实现开放标准 Unified Harness Protocol (UHP)。
+- [Punky971210/dsh-punky-swarm](https://github.com/Punky971210/dsh-punky-swarm) —— 为 DeepSeek Harness agent 群提供引擎强制的护栏：质量门楚拒绝半成品工作，安全检查点可原地恢复——让 AI 团队不致于崩溃，而不仅仅是运行中。
 
 ## UI / 客户端
 
@@ -3374,6 +3387,9 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [XucroYuri/dsh-llm-oauth-ui](https://github.com/XucroYuri/dsh-llm-oauth-ui) —— 为 DeepSeek Harness 提供 OAuth 登录状态展示，并为未来 Web UI 支持做准备。
 - [Che-Year/dsh-pet-lulu](https://github.com/Che-Year/dsh-pet-lulu) —— 一个制作精美、适配终端与 Web 的 DeepSeek Harness (dsh) 桦宠插件，使用 lulu 与 capybara 项目的素材。
 - [mldhao/dsh-blue-archive-shiroko](https://github.com/mldhao/dsh-blue-archive-shiroko) —— 蓝档风格的 DSH 主题，搭配白子（伊康）桦宠、Codex 风格回复气泡、摸摸效果与完成提示音。
+- [Icather/dsh-clean-desktop-shell](https://github.com/Icather/dsh-clean-desktop-shell) —— DSH 纯净桌面壳：双击像普通软件一键启动，后端活性实时监测 + 托盘快捷启停，零视觉改造。
+- [jkamkk/dsh-liquid-glass-input](https://github.com/jkamkk/dsh-liquid-glass-input) —— DSH web GUI 的液体玻璃输入卡片：kube.io SVG 折射效果搭配耦合弹簧按压动画。
+- [NeoXider/neoxider-agent-deck](https://github.com/NeoXider/neoxider-agent-deck) —— 面向 DeepSeek Harness 的动画桌面伴侣——实时 agent 面板、迷你小对话、流式回复、模型路由、上下文压力以及原生命令，一个可偷靠屏边的小插件。
 
 ## Skill
 
@@ -3577,6 +3593,8 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [fishzjp/qa-skills](https://github.com/fishzjp/qa-skills) —— 让 AI 像资深测试工程师一样工作：全生命周期 QA Agent Skills 框架——方法论 + 10 Skills + 可复现 Benchmark（Claude Code 等 Agent 可用）。
 - [nullptr-DZF/dsh-academic-research-skills](https://github.com/nullptr-DZF/dsh-academic-research-skills) —— 面向 DeepSeek Harness 的学术研究技能包（deepseek-harness-plugin、dsh-plugin）。
 - [suyukun/dsh-tech-selection](https://github.com/suyukun/dsh-tech-selection) —— 模型无关的技术选型调研协议：量化需求、T1-T6 来源分级、质量门槛、可溯源的结论，任何 AI agent（DSH/Claude/Cursor/Codex）都可遵循。
+- [Kenerlee/dsh-moments-aieo](https://github.com/Kenerlee/dsh-moments-aieo) —— 将 AIEO（GEO/AEO）交付法打包为 DeepSeek Harness 套件：五个共享问题库上的 moments-aieo-* 系列技能。
+- [kingselyjoe/xhs-chaijie-dsh](https://github.com/kingselyjoe/xhs-chaijie-dsh) —— DSH 原生小红书账号与竟品深度拆解 Skill：真实封面审计、爆款资产复用与可视化 HTML 报告。
 ## 资源
 
 - [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) —— 官方源码仓库。  `⭐38238`


### PR DESCRIPTION
自动扫描收录：新增 18 条社区 DSH 插件（去重后）。仅改 README.md / README.zh-CN.md。由每日扫描自动化生成，PR 巡检会自动核验链接真实性与格式后合并。