### PR TITLE
docs: add handbook to runtime section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ _DSH's core composition mechanism: a **profile** stacks bundle patch layers, the
 
 _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime-level infrastructure (diagnostics, ops, session management, approval policies)._
 
+- [sandbaseai/deepseek-harness-handbook](https://github.com/sandbaseai/deepseek-harness-handbook) — Agent-first, multilingual operator handbook for DeepSeek Harness architecture, MCP, skills, subagents, sandboxing, and source-backed troubleshooting.
 - [menotbobbybrown/create-dsh-app](https://github.com/menotbobbybrown/create-dsh-app) — 1-Line AI Agent Scaffolding Generator for DeepSeek Harness (dsh): `npx create-dsh-app my-agent` scaffolds a production-ready agent pre-wired with MCP tools, long-term memory, and web browsing.
 - [Airmetro/dsh-update-checker](https://github.com/Airmetro/dsh-update-checker) — Update management for DeepSeek Harness and its plugins: dual-source npm/GitHub semver checks, locale banner, one-click updates with backup/rollback, and watchdog restart.
 - [Liu-Bot24/dsh-tunnel-client](https://github.com/Liu-Bot24/dsh-tunnel-client) — Cross-platform desktop client for launching local DSH and securely accessing remote DSH through system OpenSSH tunnels.


### PR DESCRIPTION
Add the DeepSeek Harness Handbook to the visible Harnesses & Runtimes section while keeping its existing Resources entry.

The handbook is an independent, source-backed, multilingual operator guide for architecture, MCP, skills, subagents, sandboxing, and troubleshooting. This gives runtime readers a direct path to documentation without changing any plugin claims.