### PR TITLE
Add dsh-completion-guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,6 +929,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [IkariKr/dsh-orbit](https://github.com/IkariKr/dsh-orbit) — Secure self-hosting and fleet layer for DeepSeek Harness.
 - [yexi-by/dsh-unrestricted](https://github.com/yexi-by/dsh-unrestricted) — Toggleable jailbreak/unrestricted-prompt plugin for DeepSeek Harness Web, with multi-mode support, subagent propagation, and anchor-compatibility checks.
 - [unknowbug/dsh-thinking-loop-guard](https://github.com/unknowbug/dsh-thinking-loop-guard) — Detect & break thinking-chain loops in DSH agents at the turn boundary (no proxy). Ported from ollama-loop-guard.
+- [GreenLv/dsh-completion-guard](https://github.com/GreenLv/dsh-completion-guard) — Task-contract and completion-certification layer for DeepSeek Harness: eight lifecycle hooks keep an immutable requirement ledger, restore the bounded contract after /compact or resume, and block Goal and task-completion claims until a checkpoint binds matching evidence; fail-closed, privacy-preserving bounded evidence.
 
 ## Session & Memory Management
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -935,6 +935,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 - [IkariKr/dsh-orbit](https://github.com/IkariKr/dsh-orbit) —— 面向 DeepSeek Harness 的安全自托管与舰队层。
 - [yexi-by/dsh-unrestricted](https://github.com/yexi-by/dsh-unrestricted) —— DeepSeek Harness Web 可开关破限提示词插件，支持多模式、子代理和锚点兼容检查。
 - [unknowbug/dsh-thinking-loop-guard](https://github.com/unknowbug/dsh-thinking-loop-guard) —— 在回合边界检测并打断 DSH agent 的思考链循环（无需代理）。移植自 ollama-loop-guard。
+- [GreenLv/dsh-completion-guard](https://github.com/GreenLv/dsh-completion-guard) —— 任务合同与完成认证层:八个生命周期 hook 维护不可变需求账本,/compact 或会话恢复后重建有界合同,完成声明必须通过 checkpoint 绑定匹配证据,否则 fail-closed 阻止 Goal 与整任务完成;证据有界脱敏存储。
 
 ## 会话与记忆管理
 


### PR DESCRIPTION
Add [dsh-completion-guard](https://github.com/GreenLv/dsh-completion-guard) to **Security & Permissions** (it is a fail-closed completion gate, alongside the verifier/authorization plugins).

dsh-completion-guard is a task-contract and completion-certification layer for DeepSeek Harness: eight lifecycle hooks keep an immutable requirement ledger, restore the bounded contract after `/compact` or session resume, and block Goal/task-completion claims until a checkpoint binds matching evidence; fail-closed, privacy-preserving bounded evidence.

- npm: `dsh plugin --profile web add dsh-completion-guard@0.2.1` (published 2026-08-29; renamed from dsh-context-guard to avoid a name collision).
- Verified installed and running against dsh 0.1.1-rc.2 in a live web profile.

Change adds one row to each README (en + zh-CN) only.