### PR TITLE
Add dsh-brainagent to Session & Memory Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,6 +1292,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [Movingtoleveltwo/dsh-revert](https://github.com/Movingtoleveltwo/dsh-revert) — Modern conversation revert/retry plugin for DeepSeek Harness: pure GUI interaction, in-place prompt tweaking, dual-engine safe recovery across workspace and external files.
 - [Yidien/dsh-capture-window](https://github.com/Yidien/dsh-capture-window) — Bypass-capture plugin for DeepSeek Harness: drop stray ideas into an isolated quiet new session without breaking the main-line context.
 - [nickkkkkk123123/dsh-resume-on-restart](https://github.com/nickkkkkk123123/dsh-resume-on-restart) — Auto-wakes the main agent after a DSH service restart — compares last-run timestamps, posts a recovery notice with humanized downtime, and delivers it so interrupted work picks itself back up. Runs on plain cordis ctx, packaged-DSH-Desktop ready.
+- [dsh-brainagent](https://github.com/stas130286-blip/dsh-brainagent) — Brain-inspired cognitive plugin: episodic, semantic, procedural and emotional memory, goal stack with time triggers, curiosity-driven autonomous research and proactive initiatives.
 
 ## Cost & Usage Tracking
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1297,6 +1297,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [Movingtoleveltwo/dsh-revert](https://github.com/Movingtoleveltwo/dsh-revert) —— DeepSeek Harness 现代化对话回退与重试插件：纯 UI 图形交互、原地 Prompt 微调、支持工作区与外部文件双引擎安全恢复。
 - [Yidien/dsh-capture-window](https://github.com/Yidien/dsh-capture-window) —— DeepSeek Harness 旁路捕捉插件：随手丢想法进独立的安静新会话，不打断主线上下文。
 - [nickkkkkk123123/dsh-resume-on-restart](https://github.com/nickkkkkk123123/dsh-resume-on-restart) —— 检测 DSH 服务重启后自动唤醒主 agent —— 对比上次运行时间、人性化播报中断时长，并把提示消息投递回来让中断的工作自动恢复。仅依赖 cordis ctx 服务，兼容 DSH Desktop 打包环境。
+- [dsh-brainagent](https://github.com/stas130286-blip/dsh-brainagent) —— 受大脑启发的认知插件:情景、语义、程序与情绪记忆,带时间触发器的目标栈、好奇心驱动的自主研究与主动提议。
 
 ## 成本与用量统计
 


### PR DESCRIPTION
## What

Adds [dsh-brainagent](https://github.com/stas130286-blip/dsh-brainagent) to the Session & Memory Management section (EN + ZH READMEs kept in sync). Pure insertions: one new line per file, no existing lines touched.

## Entry

Brain-inspired cognitive plugin for DeepSeek Harness: episodic, semantic, procedural and emotional memory with reinforcement-learning signals, a goal stack with time triggers, curiosity-driven autonomous web research, and proactive initiatives.

## Checklist

- [x] Repo is public and carries the `dsh-plugin` and `deepseek-harness` topics
- [x] Project is real and working: v0.9.27 live, 915/915 tests, GitHub Actions CI green, published to npm as `dsh-brainagent`
- [x] Description is factual and hype-free
- [x] Diff is insert-only (verified via git diff: every changed line starts with +)
- [x] Allow edits by maintainers is enabled