### PR TITLE
Add dsh-locale-ru (Russian locale pack) to UI / Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -2667,6 +2667,7 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [ddtcorex/dsh-maestro-supervisor](https://github.com/ddtcorex/dsh-maestro-supervisor) — Supervisor daemon for DSH Web resilience — auto-detects crashes, rolls back to last-known-good, and reports.
 
 ## UI / Clients
+- [warment/dsh-locale-ru](https://github.com/warment/dsh-locale-ru) — Russian (Русский) language pack for the DSH Web UI: 33 namespaces / 1061 strings (100% coverage) registered through the official dsh-client-locale plugin API; live language switching without reload, formal register, unified glossary, CI drift-check against upstream; also localizes permission preset display names via a config layer. MIT — install: `dsh plugin --profile web add github:warment/dsh-locale-ru`.
 - [776138506/pinpoint](https://github.com/776138506/pinpoint) — Point-and-annotate on any webpage, then send the screenshot plus structured text straight into a DSH session (DSH plugin + browser extension).
 - [Jstn-1g/dsh-live-voice](https://github.com/Jstn-1g/dsh-live-voice) — DSH Live Voice preview: consent-bound voice add-on for DeepSeek Harness with exact-Session isolation and one bounded manual audio turn.
 - [tianhanly/dsh-official-port-nav](https://github.com/tianhanly/dsh-official-port-nav) — Perfectly replicates DeepSeek's official right-side chat navigation inside Harness.


### PR DESCRIPTION
Adds [warment/dsh-locale-ru](https://github.com/warment/dsh-locale-ru) to **UI / Clients**.

Russian locale pack for the DSH Web UI: 33 namespaces / 1061 strings (100% coverage) via the official `dsh-client-locale` plugin API; live language switching, formal register, unified glossary, CI drift-check against upstream; permission preset display names localized through a config layer. MIT, Release v0.1.0, carries the `dsh-plugin` + `dsh` topics. Install: `dsh plugin --profile web add github:warment/dsh-locale-ru`.