### PR TITLE
fix: add missing description to vlln/dsh-navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -3001,7 +3001,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [SenmuuuuW/dsh-group-photo](https://github.com/SenmuuuuW/dsh-group-photo) — Beta-farewell photo wall: a Polaroid-style group-photo site with zero-permission GitHub OAuth and an allowlist check, wrapped as a DSH skill.  `⭐12`
 - [Small-tailqwq/dsh-tps](https://github.com/Small-tailqwq/dsh-tps) — A simple TPS (tokens-per-second) plugin.
 - [SnowCrescenter-tech/dsh-launcher](https://github.com/SnowCrescenter-tech/dsh-launcher) — One-click portable Windows launcher (no Node.js, pnpm, or CLI required).
-- [vlln/dsh-navbar](https://github.com/vlln/dsh-navbar)
+- [vlln/dsh-navbar](https://github.com/vlln/dsh-navbar) — Conversation node navigation bar: jump between user messages from a right-edge node strip.
 - [Blaczz/dsh-turn-dots](https://github.com/Blaczz/dsh-turn-dots) — Codex-style conversation turn rail: one dot per user turn on the left edge, hover to enlarge and preview, click to jump, with a scroll-spy active marker. — Conversation node navigation bar: jump between user messages from a right-edge node strip.
 - [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) — Real-time conversation outline for the DSH Web session page: a tree of user questions and Markdown headings (H1-H6) that updates live during streaming, with click-to-jump highlight, expand-depth control, search, and per-session favorites.
 - [vlln/dsh-task-status](https://github.com/vlln/dsh-task-status) — Background task status bar with task progress and live output tail on the conversation page.


### PR DESCRIPTION
The EN entry was missing its description (ZH + repo confirm it: conversation node navigation bar). One-line fix, `+1 / -1`, single commit.