### PR TITLE
Add dsh-squeeze-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,6 +1046,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 
 - [TsFreddie/dsh-compaction-instant](https://github.com/TsFreddie/dsh-compaction-instant) — LLM-free lossless* compaction engine for DeepSeek Harness.
+- [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) — Manual budget-targeted context compression for DeepSeek Harness: the conversation model picks the ranges to summarize and a cheap flash-tier model route writes the checkpoint summaries. Install: `dsh plugin add dsh-squeeze-command` (npm).
 - [warrenop/open-preset-harness](https://github.com/warrenop/open-preset-harness) — DSH memory plugin (`dsh-tool-project-memory`): shared project organizational memory across presets — recall, remember, memory_status.
 - [a903067276-rgb/dsh-backup](https://github.com/a903067276-rgb/dsh-backup) — Automated backups of DSH sessions, config and custom directories — scheduled or manual, packed as tgz with rotation.
 - [anweat/dsh-context-console](https://github.com/anweat/dsh-context-console) — Complete context workbench for DeepSeek Harness: trajectory brick wall, Prompt/Skill/MCP/Tools management, cache history, message forge, and session-log recovery.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1042,6 +1042,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 _跨会话记忆、checkpoint、会话置顶与导航插件。_
 
 - [TsFreddie/dsh-compaction-instant](https://github.com/TsFreddie/dsh-compaction-instant) —— 面向 DeepSeek Harness 的无 LLM、无损（近似）压缩引擎。
+- [hardes11/dsh-squeeze-command](https://github.com/hardes11/dsh-squeeze-command) —— 手动、面向 token 预算的上下文压缩插件：由对话模型圈定要总结的范围，廉价的 flash 级模型路由生成检查点摘要。安装：`dsh plugin add dsh-squeeze-command`（npm）。
 - [warrenop/open-preset-harness](https://github.com/warrenop/open-preset-harness) —— DSH Memory 插件（`dsh-tool-project-memory`）：跨 preset 共享的项目组织记忆——recall、remember、memory_status。
 - [a903067276-rgb/dsh-backup](https://github.com/a903067276-rgb/dsh-backup) —— DSH 会话、配置与自定义目录的自动化备份——定时或手动触发，打包为带轮转的 tgz。
 - [anweat/dsh-context-console](https://github.com/anweat/dsh-context-console) —— 面向 DeepSeek Harness 的完整上下文工作台：会话轨迹砖墙、Prompt/Skill/MCP/Tools 双栏管理、缓存与历史记录、模拟消息注入与 sessionlog 修复。


### PR DESCRIPTION
**Name:** dsh-squeeze-command
**Link:** https://github.com/hardes11/dsh-squeeze-command
**Category:** Session & Memory Management
**Description:** Manual budget-targeted context compression for DeepSeek Harness: the conversation model picks the ranges to summarize and a cheap flash-tier model route writes the checkpoint summaries.

Checklist:
- [x] Repo carries the `dsh` / `dsh-plugin` topic
- [x] Both README.md and README.zh-CN.md edited (one inserted line each)
- [x] Entry format matches the section style; insert-only diff
- [x] Description is factual, hype-free
- [x] Real, working, publicly accessible (npm: dsh-squeeze-command@0.1.1, MIT, `dsh plugin add dsh-squeeze-command` verified)