### PR TITLE
Add ice5kysl/dsh-workspace-kit (enhanced workspace sidebar for the DSH Web UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4173,6 +4173,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [ijry/DeepSeek-Harness-Desktop-Ultra](https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra) — DeepSeek Harness desktop client wrapper built on Tauri instead of Electron for a much smaller footprint.
 - [Olympianz/dsh-xiaomili](https://github.com/Olympianz/dsh-xiaomili) — Xiaomili (dsh-xiaomili) — a golden-retriever secretary plugin docked beside your chatbox: listens in on conversations in real time, detects intent, extracts keywords/concepts, auto-generates secretary briefings, with persistent memory.
 - [WLV-ZEDD/dsh-btw](https://github.com/WLV-ZEDD/dsh-btw) — DeepSeek Harness side-assistant dock & drawer.
+- [ice5kysl/dsh-workspace-kit](https://github.com/ice5kysl/dsh-workspace-kit) — Enhanced workspace sidebar for the DSH Web UI: ⌘K Spotlight search, soft workspace archive/restore, per-workspace SVG icons & colors, drag-to-reorder.
 
 ## Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4171,6 +4171,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [ijry/DeepSeek-Harness-Desktop-Ultra](https://github.com/ijry/DeepSeek-Harness-Desktop-Ultra) —— DeepSeek Harness 桌面客户端封装版本，基于 Tauri 而不是 Electron，体积更小。
 - [Olympianz/dsh-xiaomili](https://github.com/Olympianz/dsh-xiaomili) —— 小米粒（dsh-xiaomili）—— 常驻 chatbox 右侧的金毛秘书插件：实时旁听对话、识别意图、提取关键词/概念、自动生成秘书简报，记忆可持久化。
 - [WLV-ZEDD/dsh-btw](https://github.com/WLV-ZEDD/dsh-btw) —— DeepSeek Harness 侧边助手 Dock 与抽屉。
+- [ice5kysl/dsh-workspace-kit](https://github.com/ice5kysl/dsh-workspace-kit) —— 增强 DSH Web UI 工作区侧栏：⌘K Spotlight 搜索、工作区软归档/恢复、每工作区 SVG 图标与强调色、拖拽排序。
 
 ## Skill
 


### PR DESCRIPTION
Adds [ice5kysl/dsh-workspace-kit](https://github.com/ice5kysl/dsh-workspace-kit) under **UI / Clients**.

A Cordis bundle plugin for the dsh Web profile: an enhanced workspace sidebar (archive folding, drag reorder, per-workspace SVG icons & colors) plus ⌘K Spotlight search and session content search. Host face ships `workspace_find`/`workspace_list` model tools and `/workspace-find`/`/workspace-list` commands. Repo carries the `dsh-plugin` / `dsh` / `deepseek-harness` topics; v0.1.0 released.

- Pure insertions: `README.md` +1 line, `README.zh-CN.md` +1 line, no other changes.