### PR TITLE
add: keeshakulbida948-tech/dsh-plugin-sticker (emoji sticker plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3263,6 +3263,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [chen-001/dsh-chat-width](https://github.com/chen-001/dsh-chat-width) — Adjusts the width of DSH replies.
 - [dingyi222666/dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) — Notifications for four session states (completion etc.), via browser alerts or prompt injection.
 - [hellodigua/dsh-emoji](https://github.com/hellodigua/dsh-emoji) — Automatically adds emoji to AI replies.
+- [keeshakulbida948-tech/dsh-plugin-sticker](https://github.com/keeshakulbida948-tech/dsh-plugin-sticker) — Emoji-sticker plugin for DeepSeek Harness: the AI searches and sends stickers from a built-in 109-image whale-girl meme pack, rendered inline in the chat bubble by a custom client toolview (no file downloads); pairs with dsh-plugin-fun.
 - [icodesign/orbis](https://github.com/icodesign/orbis) — Mobile client for DeepSeek Harness remote control.
 - [lhh010/dsh-input-history](https://github.com/lhh010/dsh-input-history) — Terminal-style input history for the Web UI: recall sent messages with Ctrl+Up/Ctrl+Down; zero core changes.
 - [lhh010/dsh-minigames](https://github.com/lhh010/dsh-minigames) — Right-side panel with 18 offline minigames (Tetris, Minesweeper, 2048, Sudoku, etc.) and an extensible game registry.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3246,6 +3246,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [chen-001/dsh-chat-width](https://github.com/chen-001/dsh-chat-width) —— 调整 DSH 回复区域宽度。
 - [dingyi222666/dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) —— 会话完成等四种状态的通知响应，支持浏览器提示与提示词。
 - [hellodigua/dsh-emoji](https://github.com/hellodigua/dsh-emoji) —— 为 AI 回复自动添加表情。
+- [keeshakulbida948-tech/dsh-plugin-sticker](https://github.com/keeshakulbida948-tech/dsh-plugin-sticker) —— 表情包插件：AI 按情境搜索并发送内置 109 张表情包（蓝发鱼娘/大肥鱼梗图），经自定义 client toolview 直接内嵌渲染在对话气泡里（无需点击下载），配合 dsh-plugin-fun 效果最佳。
 - [icodesign/orbis](https://github.com/icodesign/orbis) —— DeepSeek Harness 远程控制的移动端客户端。
 - [lhh010/dsh-input-history](https://github.com/lhh010/dsh-input-history) —— Web 输入历史：Ctrl+Up / Ctrl+Down 像终端一样召回已发送消息，零核心改动。
 - [lhh010/dsh-minigames](https://github.com/lhh010/dsh-minigames) —— Web UI 右侧小游戏面板：18 款离线小游戏（俄罗斯方块/扫雷/2048/数独等），可扩展游戏注册表。


### PR DESCRIPTION
Add [dsh-plugin-sticker](https://github.com/keeshakulbida948-tech/dsh-plugin-sticker) to UI / Clients — AI sends emoji stickers from a built-in 109-image pack, rendered inline in chat bubbles via a custom client toolview. Repo carries the \dsh\ and \dsh-plugin\ topics.