### PR TITLE
Auto-add 11 DSH plugins (20260907 scan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,12 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [po-et/dsh-http-probe](https://github.com/po-et/dsh-http-probe) — DeepSeek Harness plugin: http_probe tool — check status, latency and headers of any HTTP endpoint.
 - [hyzyn/dsh-safe](https://github.com/hyzyn/dsh-safe) — Startup safety fuse for DSH: when an incompatible community plugin breaks startup, automatically disables the bad plugin and retries.
 - [wentao75/dsh-remote-auth](https://github.com/wentao75/dsh-remote-auth) — Mobile remote-access authentication plugin for DeepSeek Harness.
+- [baihejiangnan/deepseek-harness-desktop](https://github.com/baihejiangnan/deepseek-harness-desktop) — Tri-platform-compatible DSH desktop launcher: fully isolated, parallel multi-instance sessions with a collaborative canvas for orchestrating agent workflows; portable EXE build, ~18MB (under 20MB); dual-isolation design keeps it compatible with both stock and heavily-patched DSH builds regardless of upstream updates.
+- [dll61/remote-coding-workstation-template](https://github.com/dll61/remote-coding-workstation-template) — Run DSH and CloudCLI on a desktop, then drive them remotely from phone/tablet over xEdge or Tailscale private networking; CloudCLI can front Codex, Claude Code, or DeepSeek depending on license, with RustDesk for full Windows desktop control.
+- [EthanYoQ/Invoice-Downloader](https://github.com/EthanYoQ/Invoice-Downloader) — Invoice collection and expense-reporting tool: bulk-collects PDF/OFD/XML invoices from email, OCRs and classifies them, and generates an Excel summary; ships Windows/macOS desktop apps plus a DSH plugin.
+- [Kaizin0226/dsh-supergrok](https://github.com/Kaizin0226/dsh-supergrok) — Unofficial SuperGrok OAuth integration and Grok-optimized mode for DSH 0.1.2-rc.1, with required core patches.
+- [MichengAI/dsh-btw](https://github.com/MichengAI/dsh-btw) — One-shot, read-only side-question plugin for DSH: answers from the current context in an independent bubble, without executing any tools.
+- [rickylabs/harness](https://github.com/rickylabs/harness) — Monorepo of DeepSeek Harness (dsh) plugin packages — the deterministic coordinator layer.
 
 ## Security & Permissions
 
@@ -1118,6 +1124,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [kanchengw/dsh-assembly.resume](https://github.com/kanchengw/dsh-assembly.resume) — Import local Codex and Claude sessions into DeepSeek Harness.
 - [leonardoxr/dsh-companion](https://github.com/leonardoxr/dsh-companion) — Read-only workspace and session JSON API plugin for DeepSeek Harness native clients.
 - [DDDonzy/dsh-history-rewind](https://github.com/DDDonzy/dsh-history-rewind) — Session/workspace branch-history manager for DSH: conversation and workspace snapshots, free multi-branch jumping, rewind (session-only / code-only / dual-track full rewind), same-window in-place hot reload, shadow Git repo with zero pollution and second-level snapshots, KV-cache friendly.
+- [GooDAnDReaDY/dsh-session-control](https://github.com/GooDAnDReaDY/dsh-session-control) — Session management for the DeepSeek Harness sidebar: pin conversations, search their contents, read archived transcripts and hide the noise.
 - [Starry0214/dsh-memory](https://github.com/Starry0214/dsh-memory) — Global auto-memory plugin for DeepSeek Harness (DSH): injects memory at session start, a memory_search retrieval tool, and compaction-checkpoint archive reminders (zero-write-reminder policy).
 - [EarzuChan/DshVibeLearning](https://github.com/EarzuChan/DshVibeLearning) — A Vibe Learning plugin made for DeepSeek Harness.
 - [chenhw7/dsh-memory](https://github.com/chenhw7/dsh-memory) — Cairn — long-term memory for the DeepSeek Harness (@chenhw7/dsh-memory). Persistent cross-session memory: facts, preferences, corrections, lessons. BM25 retrieval, three-layer scoping, human-confirmed writes.
@@ -1538,6 +1545,7 @@ _Token usage, cost dashboards, and budget-alert plugins._
 - [boNeXY226/dsh-cost-chip](https://github.com/boNeXY226/dsh-cost-chip) — `/cost` command plus a floating cost chip showing session spend.
 - [better-er/dsh-live-token-stats](https://github.com/better-er/dsh-live-token-stats) — DSH Web plugin: real-time token status bar below the composer using the official DeepSeek BPE tokenizer, showing streaming TPS, output tokens and time-to-first-token, and comparing the last step's estimate vs. actual — self-contained, no dsh source changes.
 - [my-dsh/dsh-token-usage-dashboard](https://github.com/my-dsh/dsh-token-usage-dashboard) — Cross-session token usage dashboard plugin for DeepSeek Harness: SQLite-backed capture + browser dashboard panel.
+- [zouxiaoyang/dsh-commandcode-usage](https://github.com/zouxiaoyang/dsh-commandcode-usage) — CommandCode usage & balance panel for DeepSeek Harness / DSH.
 - [WFMinerva/dsh-turn-cost](https://github.com/WFMinerva/dsh-turn-cost) — Per-turn real cost under every assistant reply: CNY at official peak/off-peak rates with cache-hit ratio; fully local, zero telemetry.
 - [misakimiku2/dsh-cost-display](https://github.com/misakimiku2/dsh-cost-display) — Displays session cost.
 - [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) — Cost ledger tracking spend over time.
@@ -2246,6 +2254,7 @@ _Code generation, refactoring, review, repo-level engineering plugins._
 - [shine-233/dsh-codex](https://github.com/shine-233/dsh-codex) — Monorepo porting openai/codex capabilities into DeepSeek Harness (dsh): wire-protocol contract, sandbox, policy engine, session suite, edit fusion, prompt assets, and porting ledger.
 - [zilliztech/dsh-milvus](https://github.com/zilliztech/dsh-milvus) — Read-only DSH Web plugin for inspecting and searching Milvus or Zilliz Cloud collections from chat, including scalar, BM25, dense, and hybrid queries.
 - [ByxHuster/DSH-Paper-Highlighting-Agent](https://github.com/ByxHuster/DSH-Paper-Highlighting-Agent) — An interactive and customized paper highlighting tool built upon DeepSeek Harness (DSH), still under development.
+- [Mekansm1/DSH-WebGIS](https://github.com/Mekansm1/DSH-WebGIS) — DeepSeek Harness (DSH) WebGIS plugin: map reading, map manipulation, and 3D world comprehension.
 
 - [lemonxiny55/dsh-code-index](https://github.com/lemonxiny55/dsh-code-index) — Semantic repo index plugin: tree-sitter symbol index, ranked symbol search, and a bounded auto-updating repo map injected into the system prompt — fills the gap left by dsh's lack of an aider-style repo-map / Cursor `@Codebase` capability.
 - [lvxinrong/dsh-archscope](https://github.com/lvxinrong/dsh-archscope) — Evidence-driven system architecture reconnaissance for DeepSeek Harness.
@@ -2730,6 +2739,7 @@ _Long-running loop workflows: auto-research, deep-research, self-refine, iterati
 - [maskshell/solidforge-dsh](https://github.com/maskshell/solidforge-dsh) — A convergence-engineering (Loop-Engineering) system for DeepSeek Harness, shipped both as a DSH preset and as a global plugin usable from any session. Converge → spec → implement: parallel dual-loop TDD convergence gates, adversarial cross-source review, claim-by-claim citation checks against sources, and prior-art collision search — every gate leaves an honest record and never silently turns green.
 - [leinasi2014/dsh-rlm](https://github.com/leinasi2014/dsh-rlm) — Minimal persistent Python RLM loop plugin for DeepSeek Harness
 - [que3sui/dsh-darwin](https://github.com/que3sui/dsh-darwin) — DeepSeek Harness (dsh) 双插件自进化架构：dsh-sentinel 机械挖掘会话日志生成问题工单 + dsh-forge 分级合成/评测门/确定性回滚 | Two-plugin self-evolution for DSH: hindsight mining, gated synthesis, deterministic rollback (verified in simulation lab)
+- [grloper/dsh-deep-research](https://github.com/grloper/dsh-deep-research) — Kestrel — a research engine that can't cite what a source never said: citations are admitted only when the quote is mechanically located in the source, and corroboration is counted in independent origins rather than source count. DeepSeek Harness plugin + standalone library, zero dependencies.
 
 - [2672243194/dsh-read-url](https://github.com/2672243194/dsh-read-url) — DeepSeek Harness URL reader: fetch any page and return clean main-content text/Markdown. Auto charset detection (GBK/GB2312/UTF-8/Big5), token-efficient (6000-char cap, cache, offset), zero deps, no API key.
 - [guo6x/dsh-pilot](https://github.com/guo6x/dsh-pilot) — Give your DSH agent hands: drive a real browser (Edge/Chrome over CDP) from the chat — ref-driven clicking, per-session browsers, and a live cockpit panel. Zero runtime deps, no API key.
@@ -3088,6 +3098,7 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [776138506/pinpoint](https://github.com/776138506/pinpoint) — Point-and-annotate on any webpage, then send the screenshot plus structured text straight into a DSH session (DSH plugin + browser extension).
 - [adegams/dsh-explore-button](https://github.com/adegams/dsh-explore-button) — Floating directory explorer for the DSH Web GUI: a top-right quick-access bar plus a modal file browser (list/tree navigation, breadcrumb, file viewer on click), and clickable file-path links in chat messages (e.g. `AGENTS.md`) that open directly in the viewer; exposes `/api/fs/list` + `/api/fs/read`, injected via `webserver/index-inject`.
 - [Jstn-1g/dsh-live-voice](https://github.com/Jstn-1g/dsh-live-voice) — DSH Live Voice preview: consent-bound voice add-on for DeepSeek Harness with exact-Session isolation and one bounded manual audio turn.
+- [zhm20001/dsh-diary](https://github.com/zhm20001/dsh-diary) — Diary plugin for DSH (DeepSeek Harness): a letter-paper-styled web page for journaling — the original entry is saved first, then an AI annotation is generated on top.
 - [tianhanly/dsh-official-port-nav](https://github.com/tianhanly/dsh-official-port-nav) — Perfectly replicates DeepSeek's official right-side chat navigation inside Harness.
 - [TussalZeus18028/dsh-open-folder](https://github.com/TussalZeus18028/dsh-open-folder) — Open-folder plugin for DeepSeek Harness (dsh-plugin).
 - [LamplitIsles/dsh-companion](https://github.com/LamplitIsles/dsh-companion) — dsh as a companion AI frontend in Svelte.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -898,6 +898,12 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [po-et/dsh-http-probe](https://github.com/po-et/dsh-http-probe) —— DeepSeek Harness 插件：http_probe 工具——检查任意 HTTP 端点的状态、延时与响应头。
 - [hyzyn/dsh-safe](https://github.com/hyzyn/dsh-safe) —— dsh 启动保险丝：社区插件不兼容导致 dsh 启动失败时，自动禁用坏插件并重试。
 - [wentao75/dsh-remote-auth](https://github.com/wentao75/dsh-remote-auth) —— 面向 DeepSeek Harness 的移动端远程访问鉴权插件。
+- [baihejiangnan/deepseek-harness-desktop](https://github.com/baihejiangnan/deepseek-harness-desktop) —— DeepSeek Harness 三端兼容桌面启动器：多实例完全隔离、并行协作，协作画布编排 Agent 工作流；便携版 Exe 一键启动、仅约 18M（不超过 20M）；双隔离机制让兼容性极强，无论 DSH 本体如何更新，兼容原生到野生狗奶。
+- [dll61/remote-coding-workstation-template](https://github.com/dll61/remote-coding-workstation-template) —— 电脑跑 DSH 和 CloudCLI，手机/平板通过 xEdge 或 Tailscale 私网远程使用；CloudCLI 按授权可接 Codex、Claude Code、DeepSeek，RustDesk 可控 Windows 桌面。
+- [EthanYoQ/Invoice-Downloader](https://github.com/EthanYoQ/Invoice-Downloader) —— 电子发票整理与报销准备工具：从邮箱批量收集 PDF/OFD/XML 发票，OCR 识别、分类归档并生成 Excel 汇总；提供 Windows/macOS 桌面版与 DSH 插件。
+- [Kaizin0226/dsh-supergrok](https://github.com/Kaizin0226/dsh-supergrok) —— 非官方 SuperGrok 接入与 Grok 优化模式，适配 DSH 0.1.2-rc.1 及配套核心补丁。
+- [MichengAI/dsh-btw](https://github.com/MichengAI/dsh-btw) —— DSH 一次性只读旁问插件：基于当前上下文回答，独立气泡，不执行工具。
+- [rickylabs/harness](https://github.com/rickylabs/harness) —— DeepSeek Harness (dsh) 插件包 Monorepo —— 确定性协调层。
 
 ## 安全与权限
 
@@ -1400,6 +1406,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [kanchengw/dsh-assembly.resume](https://github.com/kanchengw/dsh-assembly.resume) —— 将本地 Codex 和 Claude 会话导入 DeepSeek Harness。
 - [leonardoxr/dsh-companion](https://github.com/leonardoxr/dsh-companion) —— 为 DeepSeek Harness 原生客户端提供的只读工作区与会话 JSON API 插件。
 - [DDDonzy/dsh-history-rewind](https://github.com/DDDonzy/dsh-history-rewind) —— DSH 会话与工作区分支历史管理插件：支持对话/工作区快照，多分支自由分支跳转，回退（仅会话/仅代码/双轨全回退），同窗口原地热重载，影子 Git 仓库零污染、秒级快照、KV Cache 友好。
+- [GooDAnDReaDY/dsh-session-control](https://github.com/GooDAnDReaDY/dsh-session-control) —— 面向 DeepSeek Harness 侧边栏的会话管理插件：固定对话、搜索对话内容、读取已归档的逗字稿并隐藏噪音。
 - [Starry0214/dsh-memory](https://github.com/Starry0214/dsh-memory) —— DeepSeek Harness (DSH) 全局自动记忆插件：会话开始注入记忆、memory_search 检索工具、压缩检查点归档提醒（零写入提醒制）。
 - [EarzuChan/DshVibeLearning](https://github.com/EarzuChan/DshVibeLearning) —— 一个为 DeepSeek Harness 打造的 Vibe Learning 插件。
 - [chenhw7/dsh-memory](https://github.com/chenhw7/dsh-memory) —— Cairn —— 面向 DeepSeek Harness 的长期记忆插件（@chenhw7/dsh-memory）。持久化跨会话记忆：事实、偏好、纠错、经验教训。BM25 检索、三层作用域、人工确认写入。
@@ -1539,6 +1546,7 @@ _token 用量、成本看板与预算告警插件。_
 - [boNeXY226/dsh-cost-chip](https://github.com/boNeXY226/dsh-cost-chip) —— `/cost` 命令 + 悬浮费用胶囊，展示会话花费。
 - [better-er/dsh-live-token-stats](https://github.com/better-er/dsh-live-token-stats) —— DSH Web 插件：基于 DeepSeek 官方 BPE 分词器，在 composer 下方实时渲染 token 状态带，显示流式 TPS、输出 token 与首字延迟，并对比上一次 step 的估算与实际偏差；纯插件自包含，不改 DSH 源码。
 - [my-dsh/dsh-token-usage-dashboard](https://github.com/my-dsh/dsh-token-usage-dashboard) —— DeepSeek Harness 跨会话 Token 用量仪表盘插件：SQLite 后端采集 + 浏览器仪表盘面板。
+- [zouxiaoyang/dsh-commandcode-usage](https://github.com/zouxiaoyang/dsh-commandcode-usage) —— DSH 的 CommandCode 用量与余额面板。
 - [misakimiku2/dsh-cost-display](https://github.com/misakimiku2/dsh-cost-display) —— 成本显示。
 - [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) —— 成本账本。
 - [xie-tj/dsh-token-usage-ledger](https://github.com/xie-tj/dsh-token-usage-ledger) —— DeepSeek Harness 的持久化用量账本与 Web 用量仪表盘插件。
@@ -2257,6 +2265,7 @@ _代码生成、重构、审查、仓库级工程插件。_
 - [shine-233/dsh-codex](https://github.com/shine-233/dsh-codex) —— 把 openai/codex 能力移植进 DeepSeek Harness (dsh) 的 monorepo：线协议契约、沙箱、策略引擎、会话套件、编辑融合、提示词资产、移植台账与集成装配。
 - [zilliztech/dsh-milvus](https://github.com/zilliztech/dsh-milvus) —— 只读 DSH Web 插件，可在对话中检查和搜索 Milvus 或 Zilliz Cloud Collection，支持标量、BM25、稠密向量与混合查询。
 - [ByxHuster/DSH-Paper-Highlighting-Agent](https://github.com/ByxHuster/DSH-Paper-Highlighting-Agent) —— 基于 DeepSeek Harness (DSH) 构建的交互式论文高亮工具，仍在开发中。
+- [Mekansm1/DSH-WebGIS](https://github.com/Mekansm1/DSH-WebGIS) —— DeepSeek Harness (DSH) WebGIS 插件：地图阅读、地图操作与三维世界理解。
 
 - [lemonxiny55/dsh-code-index](https://github.com/lemonxiny55/dsh-code-index) —— 语义代码仓索引插件：基于 tree-sitter 的符号索引、排序符号搜索，并将有界的自动更新仓库地图注入系统提示词 —— 补充 dsh 缺失的类似 aider repo-map / Cursor `@Codebase` 能力。
 - [lvxinrong/dsh-archscope](https://github.com/lvxinrong/dsh-archscope) —— 面向 DeepSeek Harness 的证据驱动式系统架构侦察。
@@ -2738,6 +2747,7 @@ _长时运行的循环工作流：自动研究、深度调研、自我精炼、�
 - [maskshell/solidforge-dsh](https://github.com/maskshell/solidforge-dsh) —— 面向 DeepSeek Harness 的收敛工程（Loop-Engineering）系统，以 DSH 预设与任意会话皮可使用的全局插件两种形式交付。收敛 → 规格化 → 实现：并行 TDD 双环收敛门禁、对抗式跨源评审、对源逐条引用核查、先行技术碰撞检索——每道门控均提供诚实记录，绝不静默转绥。
 - [leinasi2014/dsh-rlm](https://github.com/leinasi2014/dsh-rlm) —— 面向 DeepSeek Harness 的极简持久化 Python RLM 循环插件。
 - [que3sui/dsh-darwin](https://github.com/que3sui/dsh-darwin) —— DeepSeek Harness (dsh) 双插件自进化架构：dsh-sentinel 机械挖掘会话日志生成问题工单 + dsh-forge 分级合成/评测门/确定性回滚。
+- [grloper/dsh-deep-research](https://github.com/grloper/dsh-deep-research) —— Kestrel —— 一个不会引用来源中不存在说法的研究引擎：只有引文在源中可被机械定位时才能被引用，企及以独立来源数而非来源总数计量交叉验证。DeepSeek Harness 插件 + 独立库，零依赖。
 
 - [2672243194/dsh-read-url](https://github.com/2672243194/dsh-read-url) —— DeepSeek Harness 网页阅读器：抓取任意网页并返回干净的正文文本/Markdown。自动识别编码（GBK/GB2312/UTF-8/Big5），省 token（6000 字符上限、缓存、offset），零依赖，无需 API key。
 - [guo6x/dsh-pilot](https://github.com/guo6x/dsh-pilot) —— 给你的 DSH agent 一双手：在对话中驱动真实浏览器（通过 CDP 连接 Edge/Chrome）——基于 ref 的点击、按会话隔离的浏览器实例，以及一个实时驾驶舱面板。零运行时依赖，无需 API key。
@@ -3098,6 +3108,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [youridol/dsh-launcher](https://github.com/youridol/dsh-launcher) —— DeepSeek Harness 启动器与运行环境管理器（Tauri 2 + Rust + React）。
 - [776138506/pinpoint](https://github.com/776138506/pinpoint) —— 指哪打哪：在任意网页标记元素并评论，截图+结构化文本直达 dsh 会话（dsh 插件 + 浏览器扩展）。
 - [Jstn-1g/dsh-live-voice](https://github.com/Jstn-1g/dsh-live-voice) —— DSH Live Voice 预览版：面向 DeepSeek Harness 的合规语音附加组件，精确会话隔离，支持一次受限的手动语音回合。
+- [zhm20001/dsh-diary](https://github.com/zhm20001/dsh-diary) —— dsh 日记插件：纸感信笺风 web 页写日记，原文先落盘、AI 评注后生成。
 - [tianhanly/dsh-official-port-nav](https://github.com/tianhanly/dsh-official-port-nav) —— 在 Harness 中完美复刻 DeepSeek 官方右侧聊天导航。
 - [TussalZeus18028/dsh-open-folder](https://github.com/TussalZeus18028/dsh-open-folder) —— DeepSeek Harness 打开文件夹插件（dsh-plugin）。
 - [LamplitIsles/dsh-companion](https://github.com/LamplitIsles/dsh-companion) —— 基于 Svelte 构建的 dsh 伴侣式 AI 前端。


### PR DESCRIPTION
自动扫描收录：新增 11 条社区 DSH 插件（去重后）。仅改 README.md / README.zh-CN.md。由每日扫描自动化生成，PR 巡检会自动核验链接真实性与格式后合并。