### PR TITLE
Add busabase/busabase-dsh-plugin to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2776,6 +2776,7 @@ _Long-running loop workflows: auto-research, deep-research, self-refine, iterati
 _Model Context Protocol servers that contribute tools / prompts / resources to DSH._
 
 <!-- Add entries here. -->
+- [busabase/busabase-dsh-plugin](https://github.com/busabase/busabase-dsh-plugin) — Connects DeepSeek Harness to Busabase knowledge and structured data over MCP, renders records and ChangeRequests in a live inspector, and keeps agent writes behind human review.
 - [xiaokaizhou/dsh-llm-multimodal](https://github.com/xiaokaizhou/dsh-llm-multimodal) — DSH plugin: image/video generation tools in chat, backed by an OpenAI-compatible API.
 - [ZIye1208/dsh-github-mcp](https://github.com/ZIye1208/dsh-github-mcp) — DSH plugin: GitHub MCP connection plugin, token stored in the DSH credentials center (.credentials.yaml), auto-bundles the companion panel plugin dsh-github-mcp-hint (independently uninstallable).
 - [ZIye1208/dsh-github-mcp-hint](https://github.com/ZIye1208/dsh-github-mcp-hint) — DSH plugin: GitHub MCP example-prompt panel (Settings → Plugins, random 4/30 copyable prompts) + public repo stats (stars/forks) + a gh_repo_stats model tool (star count / 14-day clone count).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2790,6 +2790,7 @@ _长时运行的循环工作流：自动研究、深度调研、自我精炼、�
 _向 DSH 贡献工具 / prompt / 资源的 Model Context Protocol server。_
 
 <!-- 在此添加条目。 -->
+- [busabase/busabase-dsh-plugin](https://github.com/busabase/busabase-dsh-plugin) —— 通过 MCP 将 DeepSeek Harness 接入 Busabase 知识与结构化数据，在实时 Inspector 中渲染记录和 ChangeRequest，并将 Agent 写入置于人工审核之后。
 - [xiaokaizhou/dsh-llm-multimodal](https://github.com/xiaokaizhou/dsh-llm-multimodal) —— DSH 插件：在聊天中提供图像/视频生成工具，基于 OpenAI 兼容 API。
 - [ZIye1208/dsh-github-mcp](https://github.com/ZIye1208/dsh-github-mcp) —— DSH 插件：GitHub MCP 连接插件，token 存 DSH 凭据中心(.credentials.yaml)，自动捆绑安装面板插件 dsh-github-mcp-hint（可独立卸载）。
 - [ZIye1208/dsh-github-mcp-hint](https://github.com/ZIye1208/dsh-github-mcp-hint) —— DSH 插件：GitHub MCP 示例提示面板（设置→插件，随机 4/30 条可复制）+ 公开仓库统计（星/fork）+ gh_repo_stats 模型工具（星数/近14天克隆量）。


### PR DESCRIPTION
## What are you adding?

- **Name:** busabase/busabase-dsh-plugin
- **Link:** https://github.com/busabase/busabase-dsh-plugin
- **Category:** MCP Servers
- **One-line description:** Connects DeepSeek Harness to Busabase knowledge and structured data over MCP, with live inspector rendering and human-reviewed writes.

## Checklist

- [x] The repo carries the `dsh-plugin` GitHub topic
- [x] I edited **both** `README.md` and `README.zh-CN.md`
- [x] Entry follows the required one-line format
- [x] Description is factual and hype-free
- [x] The project is real, working, and publicly accessible

Disclosure: I work on Busabase.