### PR TITLE
Auto-add 15 DSH plugins (20260908 scan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,6 +910,7 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [superfish058/dsh-llm-proxy](https://github.com/superfish058/dsh-llm-proxy) — DSH model-proxy plugin: per-model routing through proxies (Clash, etc.), automatic retry on failure, multimodal model mirroring, per-model connection testing, model list synced with official releases, live-applied settings page.
 - [marcosmmjr2023/dsh-h-v1](https://github.com/marcosmmjr2023/dsh-h-v1) — FreeDSH: free-first multi-model routing, automatic fallback, safe updates and Brazilian Portuguese support for DeepSeek Harness.
 - [Rainflowers686/deepseek-harness-minimal-omni](https://github.com/Rainflowers686/deepseek-harness-minimal-omni) — DeepSeek Harness Minimal Omni developer preview: minimal-by-default runtime with on-demand capabilities and model-invisible governance.
+- [bill277048-hash/DSH-guardian](https://github.com/bill277048-hash/DSH-guardian) — DSH Web UI panel to start, stop, and inspect separately deployed macOS dsh-guardian LaunchAgents; watchdog scripts are not bundled.
 
 ## Security & Permissions
 
@@ -1102,6 +1103,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [weibaohui/user-management](https://github.com/weibaohui/user-management) — DSH login gate plugin: DSH web login access control plus user/role/login-record/access-record management; the first registrant becomes admin.
 - [pure-craft/dsh-capability-panel](https://github.com/pure-craft/dsh-capability-panel) — DeepSeek Harness plugin: see what your agent can actually reach — skills, MCP servers, system tools with true in-context state, and per-session / per-preset switches.
 - [jonah791/dsh-agent-preflight](https://github.com/jonah791/dsh-agent-preflight) — Sandbox preflight plugin (split off from dsh-agent-watch): mandatory pre-restart/pre-launch checks — plugin static health (lib/src freshness / schema DSL), disk space, profile-manifest validation, patch-file validation, peer dependencies, and environment variables.
+- [zhaoxuejie/dsh-plugin-tool-guard](https://github.com/zhaoxuejie/dsh-plugin-tool-guard) — Tool-call security guard for DeepSeek Harness: dangerous-command blocking, path allowlists, sensitive-file denylists, human approval, and auditing.
 
 ## Session & Memory Management
 
@@ -1536,6 +1538,10 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [robiteame/dsh-session-tree-extension](https://github.com/robiteame/dsh-session-tree-extension) — Append-only, multi-branch conversation trees for DeepSeek Harness: immutable history nodes, forks from any historical node, standard LLM message reconstruction, versioned JSON snapshots, and an embedded Web UI tree panel.
 - [chenqiuyushuang/dsh-nexus](https://github.com/chenqiuyushuang/dsh-nexus) — Zero-configuration, cost-aware memory layer for DeepSeek Harness; design finalized, with Phase 0 scaffolding in development.
 - [weibaohui/dsh-smart-title](https://github.com/weibaohui/dsh-smart-title) — DSH smart session-title plugin: uses an LLM to summarize and rewrite the title automatically after each conversation turn.
+- [Anduin9527/dsh-document-evidence](https://github.com/Anduin9527/dsh-document-evidence) — Native PDF library for DeepSeek Harness Web with bounded evidence retrieval, page images, and source-citation highlighting.
+- [lsaint/aikito](https://github.com/lsaint/aikito) — Git-managed workspace for AI-agent instructions, skills, MCP definitions, and durable memory, with scoped synchronization across agents including DeepSeek Harness.
+- [wbushihenshuai-design/dsh-error-improvement](https://github.com/wbushihenshuai-design/dsh-error-improvement) — Standalone DeepSeek Harness plugin for user-confirmed anti-regression lessons.
+- [weibaohui/dsh-kb](https://github.com/weibaohui/dsh-kb) — DSH team knowledge-base plugin for offline knowledge sharing, browsing, full-text search, and processing; agent-only writes, based on the Karpathy LLM Wiki pattern.
 
 ## Cost & Usage Tracking
 
@@ -2246,6 +2252,8 @@ _Plugins that turn data / results into charts, diagrams, dashboards._
 - [mokuyoaxis/dsh-iris](https://github.com/mokuyoaxis/dsh-iris) — Media generation and visual understanding for DeepSeek Harness, with multi-provider routing and the integrated Iris workbench.
 - [abiddotdev/dsh-visualizer](https://github.com/abiddotdev/dsh-visualizer) — DSH plugin for visualizing agent sessions/data (upstream description minimal).
 - [svgop/dsh-rich-tracking](https://github.com/svgop/dsh-rich-tracking) — Percent-progress scoreboard for DeepSeek Harness: evidence-bound progress rows, git-captured checkpoints, and pursue/align/dismiss operator controls.
+- [boogoo619/dsh-noteboard](https://github.com/boogoo619/dsh-noteboard) — Workspace-level infinite noteboard canvas for DSH: save selected conversation content as sticky notes with optional AI distillation, then send notes back as structured references.
+- [xsluck/dsh-vidgen-plugin](https://github.com/xsluck/dsh-vidgen-plugin) — Multi-provider video and image generation plugin for DSH Web, with a ComfyUI-style node canvas, provider settings, and agent video-generation tools.
 
 ## Slides / PPT
 
@@ -2566,6 +2574,7 @@ _Code generation, refactoring, review, repo-level engineering plugins._
 - [HaoyueQin/dsh-git-review](https://github.com/HaoyueQin/dsh-git-review) — DSH Git Review — a review tab + fenced git workbench for DeepSeek Harness: file tree, diffs, lane graph, and guarded git ops.
 - [Aealen/dsh-coding-workspace](https://github.com/Aealen/dsh-coding-workspace) — Coding workspace built on git worktrees for parallel development, adding cross-session collaboration primitives, a project-grouped sidebar, and a docked workspace panel — turns DSH's single-session UI into a multi-workspace parallel-development cockpit.
 - [zhaoxuejie/dsh-plugin-todo-scanner](https://github.com/zhaoxuejie/dsh-plugin-todo-scanner) — DeepSeek Harness TODO code scanner: recursively scans local code markers into structured lists, with status management, Markdown export and a TODO Radar sidebar panel.
+- [zhchxiao123/dsh-devflow-plugins](https://github.com/zhchxiao123/dsh-devflow-plugins) — File-backed development workflow for DeepSeek Harness with durable cards, append-only history, artifact and agent checks, human approvals, and a read-only web board.
 
 ## Agents
 
@@ -2746,6 +2755,7 @@ _Reusable sub-agents / specialized agent packs runnable inside DSH._
 - [flg1217/dsh-subagent-codebuddy](https://github.com/flg1217/dsh-subagent-codebuddy) — CodeBuddy CLI ACP subagent plugin for DSH: subagent provider + subagent_codebuddy tool.
 - [gongyijie85/dsh-agent-frugality](https://github.com/gongyijie85/dsh-agent-frugality) — Multi-agent frugality defense plugin for DeepSeek Harness: read-ledger dedup, compaction-immune rules, completion gate, cheap-review lane.
 - [GooDAnDReaDY/dsh-moa](https://github.com/GooDAnDReaDY/dsh-moa) — Mixture of Agents (MoA) plugin for DeepSeek Harness with /moa slash command, file workspaces, and Live Canvas integration.
+- [fxxg023/dsh-stock-assistant](https://github.com/fxxg023/dsh-stock-assistant) — DSH A-share stock assistant with market analysis, conditional screening, six-strategy backtesting, and watch alerts using Eastmoney, Tencent, and akshare data; for research and learning.
 
 ## Loops (Auto-Research, Self-Improve, etc.)
 
@@ -2955,6 +2965,7 @@ _Model Context Protocol servers that contribute tools / prompts / resources to D
 - [STARDUSTLC666/dsh-calendar](https://github.com/STARDUSTLC666/dsh-calendar) — DeepSeek Harness calendar plugin: CalDAV schedule query, create, edit, delete and search, with Google OAuth 2.0, iCloud, Nextcloud, custom servers, and offline config self-check.
 - [creativedswork/excalidraw-editor-mcp](https://github.com/creativedswork/excalidraw-editor-mcp) — An Excalidraw canvas delivered as an MCP App for DeepSeek Harness.
 - [flg1217/dsh-web-search-openai](https://github.com/flg1217/dsh-web-search-openai) — OpenAI Responses API web-search provider for DSH (web_search tool) plus a Web settings card. Hot-pluggable plugin.
+- [MikotoMyWife/dsh-mcp-loader](https://github.com/MikotoMyWife/dsh-mcp-loader) — Lazy-loading MCP tools for DSH: one loader tool per multi-tool MCP server, per-agent tool masking, and description presets.
 
 ## Orchestrators & Aggregators
 
@@ -4350,6 +4361,10 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [jypjypjypjyp/dsh-notifier](https://github.com/jypjypjypjyp/dsh-notifier) — DSH approval, completion and error notifications via browser Notification and native Windows/macOS/Linux toasts; configurable sounds, independent notifications and a banner fallback in non-secure contexts.
 - [lnyuqian/dsh-quick-prompts](https://github.com/lnyuqian/dsh-quick-prompts) — DSH Web quick-prompt plugin: select and send preset prompts beside the permission switch, with editable prompts persisted in the project root.
 - [loyalchiiina/dsh-todo-float-ball](https://github.com/loyalchiiina/dsh-todo-float-ball) — Floating progress ball for DeepSeek Harness: keeps the agent's todo_write checklist on a persistent, draggable ball with live status colors and English/Chinese support.
+- [blauerberg/dsh-web-push-notification](https://github.com/blauerberg/dsh-web-push-notification) — Web Push notifications for DeepSeek Harness tasks, approvals, and questions.
+- [chinachat/deepseek-harness-desktop](https://github.com/chinachat/deepseek-harness-desktop) — Desktop edition of DeepSeek Harness.
+- [haverainlilili/all-pet](https://github.com/haverainlilili/all-pet) — Desktop pet monitoring AI coding agents including DeepSeek Harness, Codex, Claude Code/Desktop, and Grok; macOS GUI and cross-platform CLI.
+- [intherainof/mobile-agent](https://github.com/intherainof/mobile-agent) — Android AI-agent APK adapted from the DeepSeek Harness architecture, with file access, WebView browsing, mini-app creation, and scheduled reminders.
 
 ## Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -911,6 +911,7 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [superfish058/dsh-llm-proxy](https://github.com/superfish058/dsh-llm-proxy) — DSH 模型代理插件：按模型细粒度走代理（Clash 等）+ 失败自动重试 + 多模态模型镜像 + 逐模型测试连接，模型列表与官方同步，设置页实时生效。
 - [marcosmmjr2023/dsh-h-v1](https://github.com/marcosmmjr2023/dsh-h-v1) —— FreeDSH：为 DeepSeek Harness 提供免费优先的多模型路由、自动回退、安全更新及巴西葡萄牙语支持。
 - [Rainflowers686/deepseek-harness-minimal-omni](https://github.com/Rainflowers686/deepseek-harness-minimal-omni) —— DeepSeek Harness Minimal Omni 开发者预览：默认极简运行时，按需提供能力，并采用对模型不可见的治理机制。
+- [bill277048-hash/DSH-guardian](https://github.com/bill277048-hash/DSH-guardian) —— 在 DSH Web 界面中启动、停止和查看另行部署的 macOS dsh-guardian LaunchAgent 守护任务；不包含守护脚本本身。
 
 ## 安全与权限
 
@@ -1108,6 +1109,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 - [weibaohui/user-management](https://github.com/weibaohui/user-management) —— dsh 插件 · 用户管理：dsh web 登录门禁 + 用户/角色/登录记录/访问记录管理，首个注册者即管理员。
 - [pure-craft/dsh-capability-panel](https://github.com/pure-craft/dsh-capability-panel) —— DeepSeek Harness 插件：看清 agent 实际能触达什么——skills、MCP server、系统工具的真实上下文内状态，支持按会话/按 preset 单独开关。
 - [jonah791/dsh-agent-preflight](https://github.com/jonah791/dsh-agent-preflight) —— 沙盒预检插件（从 dsh-agent-watch 拆分）：重启/启动前强制预检——插件静态健康（lib/src 时效/schema DSL）、磁盘、profile manifest 校验、patch 文件校验、peer 依赖、环境变量。
+- [zhaoxuejie/dsh-plugin-tool-guard](https://github.com/zhaoxuejie/dsh-plugin-tool-guard) —— DeepSeek Harness 工具调用安全守卫：危险命令拦截、路径白名单、敏感文件黑名单、人工审批与审计。
 
 ## 会话与记忆管理
 
@@ -1541,6 +1543,10 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [robiteame/dsh-session-tree-extension](https://github.com/robiteame/dsh-session-tree-extension) —— DeepSeek Harness 只追加、多分支会话树：历史节点不可变，可从任意历史节点分叉，支持标准 LLM 消息重建、版本化 JSON 快照和内嵌 Web UI 树面板。
 - [chenqiuyushuang/dsh-nexus](https://github.com/chenqiuyushuang/dsh-nexus) —— DeepSeek Harness 的零配置、成本自保记忆层；设计已定稿，处于 Phase 0 环境与骨架开发阶段。
 - [weibaohui/dsh-smart-title](https://github.com/weibaohui/dsh-smart-title) —— DSH 会话智能标题插件：通过 LLM 总结改写会话标题，每轮对话后自动更新。
+- [Anduin9527/dsh-document-evidence](https://github.com/Anduin9527/dsh-document-evidence) —— DeepSeek Harness Web 原生 PDF 文档库，提供有边界的证据检索、页面图像与来源引用高亮。
+- [lsaint/aikito](https://github.com/lsaint/aikito) —— 以 Git 管理 AI 代理指令、技能、MCP 定义与持久记忆的工作区，按作用域同步到 DeepSeek Harness 等多个代理。
+- [wbushihenshuai-design/dsh-error-improvement](https://github.com/wbushihenshuai-design/dsh-error-improvement) —— 面向 DeepSeek Harness 的独立插件，记录经用户确认的防回归经验教训。
+- [weibaohui/dsh-kb](https://github.com/weibaohui/dsh-kb) —— DSH 团队知识库插件，支持离线知识共享、浏览、全文检索与加工入口；写入统一由代理执行，基于 Karpathy LLM Wiki 模式。
 
 ## 成本与用量统计
 
@@ -2256,6 +2262,8 @@ _把数据 / 结果变成图表、图形、看板的插件。_
 - [mokuyoaxis/dsh-iris](https://github.com/mokuyoaxis/dsh-iris) —— 面向 DeepSeek Harness 的多媒体生成与视觉理解插件，支持多供应商路由与集成的 Iris 工作台。
 - [abiddotdev/dsh-visualizer](https://github.com/abiddotdev/dsh-visualizer) —— 面向 DSH 的会话/数据可视化插件（上游描述较简略）。
 - [svgop/dsh-rich-tracking](https://github.com/svgop/dsh-rich-tracking) —— DeepSeek Harness 百分比进度看板：进度行绑定证据，以 Git 记录检查点，提供追进度、对齐与忽略（pursue/align/dismiss）操作。
+- [boogoo619/dsh-noteboard](https://github.com/boogoo619/dsh-noteboard) —— DSH 工作区级无限便签画布：框选会话内容保存为便签，可用 AI 提炼，并将便签作为结构化引用发回 AI。
+- [xsluck/dsh-vidgen-plugin](https://github.com/xsluck/dsh-vidgen-plugin) —— 面向 DSH Web 的多供应商视频与图片生成插件，提供 ComfyUI 风格节点画布、供应商设置与代理视频生成工具。
 
 ## 幻灯片 / PPT
 
@@ -2577,6 +2585,7 @@ _代码生成、重构、审查、仓库级工程插件。_
 - [HaoyueQin/dsh-git-review](https://github.com/HaoyueQin/dsh-git-review) — DSH Git Review — 审查标签页 + 围栏 Git 工作台：文件树、diff、lane graph、受保护的 git 操作。
 - [Aealen/dsh-coding-workspace](https://github.com/Aealen/dsh-coding-workspace) —— coding 工作台。以 git worktree 并行开发为地基，向上提供跨会话协作原语、项目分组侧栏与停靠式工作区面板，把 dsh 的单会话界面变成多工作区并行开发驶驶舱。
 - [zhaoxuejie/dsh-plugin-todo-scanner](https://github.com/zhaoxuejie/dsh-plugin-todo-scanner) —— DeepSeek Harness TODO 代码扫描插件：递归扫描本地代码标记，生成结构化清单，支持状态管理、Markdown 导出与侧边「TODO 雷达」面板。
+- [zhchxiao123/dsh-devflow-plugins](https://github.com/zhchxiao123/dsh-devflow-plugins) —— DeepSeek Harness 文件化开发工作流，提供持久卡片、只追加历史、产物与代理检查、人工审批及只读 Web 看板。
 
 ## Agent
 
@@ -2759,6 +2768,7 @@ _可在 DSH 内运行的可复用子 agent / 专用 agent 包。_
 - [flg1217/dsh-subagent-codebuddy](https://github.com/flg1217/dsh-subagent-codebuddy) —— CodeBuddy CLI ACP 子代理插件：dsh subagent provider + subagent_codebuddy 工具。
 - [gongyijie85/dsh-agent-frugality](https://github.com/gongyijie85/dsh-agent-frugality) —— 面向 DeepSeek Harness 的多代理节约防护插件：读取账本去重、抵抗压缩的规则、完成门控、平价复审通道。
 - [GooDAnDReaDY/dsh-moa](https://github.com/GooDAnDReaDY/dsh-moa) —— 面向 DeepSeek Harness 的 Mixture of Agents（MoA）插件，提供 /moa 斜杠命令、文件工作区与 Live Canvas 集成。
+- [fxxg023/dsh-stock-assistant](https://github.com/fxxg023/dsh-stock-assistant) —— DSH A 股助手，使用东方财富、腾讯行情与 akshare 数据，提供行情分析、条件选股、六种策略回测与盯盘告警；仅供研究学习。
 
 ## 循环（自动研究 / 自我改进等）
 
@@ -2964,6 +2974,7 @@ _向 DSH 贡献工具 / prompt / 资源的 Model Context Protocol server。_
 - [STARDUSTLC666/dsh-calendar](https://github.com/STARDUSTLC666/dsh-calendar) — DeepSeek Harness 日历插件：CalDAV 日程查询、创建、修改、删除与搜索，支持 Google OAuth 2.0、iCloud、Nextcloud、自定义服务及离线配置自检。
 - [creativedswork/excalidraw-editor-mcp](https://github.com/creativedswork/excalidraw-editor-mcp) —— 一个以 MCP App 形式交付给 DeepSeek Harness 的 Excalidraw 画板。
 - [flg1217/dsh-web-search-openai](https://github.com/flg1217/dsh-web-search-openai) —— 面向 dsh 的 OpenAI Responses API 网页搜索 provider（web_search 工具）+ Web 设置卡。可热拔插插件。
+- [MikotoMyWife/dsh-mcp-loader](https://github.com/MikotoMyWife/dsh-mcp-loader) —— 面向 DSH 的 MCP 工具懒加载插件：为每个多工具 MCP 服务提供一个加载工具，支持按代理屏蔽工具与描述预设。
 
 ## 编排器与聚合器
 
@@ -4347,6 +4358,13 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [jypjypjypjyp/dsh-notifier](https://github.com/jypjypjypjyp/dsh-notifier) —— DSH 审批、完成与错误事件通知：浏览器 Notification + Windows/macOS/Linux 系统原生 toast，无需额外安装；提示音可配、通知独立显示，非安全上下文自动降级横幅。
 - [lnyuqian/dsh-quick-prompts](https://github.com/lnyuqian/dsh-quick-prompts) —— DSH Web 快捷输入插件（闪电笔）：在权限切换旁一键选取并发送预设提示词，支持增删改并持久化到项目根目录。
 - [loyalchiiina/dsh-todo-float-ball](https://github.com/loyalchiiina/dsh-todo-float-ball) —— DeepSeek Harness 悬浮进度球：将 agent 的 todo_write 清单显示在持久、可拖动的悬浮球上，实时状态配色，支持中英双语。
+- [blauerberg/dsh-web-push-notification](https://github.com/blauerberg/dsh-web-push-notification) —— 为 DeepSeek Harness 任务、审批和提问提供 Web Push 推送通知。
+- [chinachat/deepseek-harness-desktop](https://github.com/chinachat/deepseek-harness-desktop) —— DeepSeek Harness 桌面版。
+- [haverainlilili/all-pet](https://github.com/haverainlilili/all-pet) —— 同时观察 DeepSeek Harness、Codex、Claude Code/Desktop 与 Grok 等 AI 编程代理的桌宠，提供 macOS 图形界面与跨平台命令行。
+- [intherainof/mobile-agent](https://github.com/intherainof/mobile-agent) —— 基于 DeepSeek Harness 架构改编的 Android AI 代理 APK，支持文件读写、WebView 浏览、小应用制作与定时提醒。
+- [YEYEYEYESHIFU/dsh-split-screen](https://github.com/YEYEYEYESHIFU/dsh-split-screen) —— 分屏工作区：在原生风格的并列面板中与多个代理聊天，支持紧凑 TUI 输入模式、键盘切换面板焦点和明暗主题。
+- [adegams/dsh-explore-button](https://github.com/adegams/dsh-explore-button) —— DSH Web 浮动目录浏览器：右上角快捷入口、列表与树形导航、面包屑和文件预览，并可点击聊天中的文件路径直接打开查看器。
+- [Blaczz/dsh-turn-dots](https://github.com/Blaczz/dsh-turn-dots) —— DSH 会话轮次导航栏：每个用户回合对应一个圆点，支持悬停预览、点击跳转与滚动位置高亮。
 
 ## Skill
 
@@ -4623,6 +4641,7 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [VanadisGithub/dsh-skill-evolution](https://github.com/VanadisGithub/dsh-skill-evolution) —— 面向 DeepSeek Harness (DSH) 的 Hermes 式技能自我进化插件：从成功的对话回合中提练可复用的 agent 技能（信号触发的 LLM 审阅），持续改进，并在 Settings 面板中统一管理。
 - [Fabian-698/dsh-upgrade-fix-012](https://github.com/Fabian-698/dsh-upgrade-fix-012) —— 诊断并修复 DeepSeek Harness 0.1.2-rc.x 升级问题的 Agent Skill：覆盖 UNKNOWN_MODEL、Session.events 移除和恢复会话时预设缺失，提供一次扫描与双重验证门。
 - [oxbshw/watch-skill](https://github.com/oxbshw/watch-skill) —— 提供带时间戳证据的视频、音频与屏幕理解能力；DeepWatch 将这些证据与独立验证带入基于官方 DeepSeek Harness 的工作区，支持 MCP、CLI、REST 与 Web。
+- [repo-cover](https://github.com/sjh9714/repo-cover) —— GitHub 社交预览卡片设计技能：生成自包含的 1280×640 HTML 卡片，提供四种编辑风格、中文等 CJK 字体排版与对比度、溢出、换行检查。
 
 ## 资源
 


### PR DESCRIPTION
自动扫描收录：新增 15 条社区 DSH 插件（去重后）。仅改 README.md / README.zh-CN.md。由每日扫描自动化生成，PR 巡检会自动核验链接真实性与格式后合并。

本批读取 /tmp/dsh_candidates_20260908.md 的 18 个候选，未重新运行扫描。原 auto-add-20260908 分支已由开放 PR #429 使用，因此保留原分支，使用 auto-add-20260908-batch2。

去重：agent-mobile/dsh-mobile-gateway、agent-mobile/dsh-mobile、agent-mobile/dsh-speech 已以 elskly-cmyk 下的旧地址包含在 #429 中；GitHub API 确认旧地址迁移到上述新 full_name，本 PR 不重复收录。排除项：0。

为满足双语条目集合一致，另补齐英文版已有的 4 条中文翻译：YEYEYEYESHIFU/dsh-split-screen、adegams/dsh-explore-button、Blaczz/dsh-turn-dots、sjh9714/repo-cover；不计入新增 15 项。保留既有重复行，不做无关清理。

验证：git diff --check 通过；仅两个 README 改动；英文新增 15 行，中文新增 19 行；两个 README 各有 4413 个唯一 GitHub full_name。本次仅创建 PR，不执行合并。