### PR TITLE
Add laodonge/col-dsh-plugin to Orchestrators & Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -3127,7 +3127,7 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [dushaobindoudou/dsh-bots](https://github.com/dushaobindoudou/dsh-bots) — DSH Web workbench for an external sdk-bots gateway, exposing bot/group chats, MCP management, and per-bot workspace settings.
 - [GooDAnDReaDY/dsh-kanban](https://github.com/GooDAnDReaDY/dsh-kanban) — DSH Kanban board with local tasks, Gitea issue synchronization, workflow columns, and agent sessions associated with tasks. The reviewed source has a rendering defect in worktree task details.
 - [EsonXie/dsh-agent-toolkit](https://github.com/EsonXie/dsh-agent-toolkit) — DSH toolkit with an agent registry, layered prompts, subagent delegation, Feishu bots and token-usage views; source builds use its workspace packages.
-- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) — Context Organization Layer for DSH/Cordis: persistent organizational Contexts (`ctx.col`), replaceable executors, verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`. Install: npm i col-dsh-plugin.
+- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) — Cordis service for DeepSeek Harness providing persistent contexts, executor bindings, confidence-label write-back rules, and event history; requires manual profile registration, with a separate example for model-tool registration.
 
 ## UI / Clients
 - [Miasakiii/dsh-miasaki](https://github.com/Miasakiii/dsh-miasaki) — Personal DSH (DeepSeek Harness) companion-project monorepo: desktop client (thin Tauri 2 shell + Win32 desktop pet + three themes) × Fleet multi-agent orchestration × Canvas plugin, three zero-coupled tracks.

--- a/README.md
+++ b/README.md
@@ -3127,6 +3127,7 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [dushaobindoudou/dsh-bots](https://github.com/dushaobindoudou/dsh-bots) — DSH Web workbench for an external sdk-bots gateway, exposing bot/group chats, MCP management, and per-bot workspace settings.
 - [GooDAnDReaDY/dsh-kanban](https://github.com/GooDAnDReaDY/dsh-kanban) — DSH Kanban board with local tasks, Gitea issue synchronization, workflow columns, and agent sessions associated with tasks. The reviewed source has a rendering defect in worktree task details.
 - [EsonXie/dsh-agent-toolkit](https://github.com/EsonXie/dsh-agent-toolkit) — DSH toolkit with an agent registry, layered prompts, subagent delegation, Feishu bots and token-usage views; source builds use its workspace packages.
+- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) — Context Organization Layer for DSH/Cordis: persistent organizational Contexts (`ctx.col`), replaceable executors, verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`.
 
 ## UI / Clients
 - [Miasakiii/dsh-miasaki](https://github.com/Miasakiii/dsh-miasaki) — Personal DSH (DeepSeek Harness) companion-project monorepo: desktop client (thin Tauri 2 shell + Win32 desktop pet + three themes) × Fleet multi-agent orchestration × Canvas plugin, three zero-coupled tracks.

--- a/README.md
+++ b/README.md
@@ -3127,7 +3127,7 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [dushaobindoudou/dsh-bots](https://github.com/dushaobindoudou/dsh-bots) — DSH Web workbench for an external sdk-bots gateway, exposing bot/group chats, MCP management, and per-bot workspace settings.
 - [GooDAnDReaDY/dsh-kanban](https://github.com/GooDAnDReaDY/dsh-kanban) — DSH Kanban board with local tasks, Gitea issue synchronization, workflow columns, and agent sessions associated with tasks. The reviewed source has a rendering defect in worktree task details.
 - [EsonXie/dsh-agent-toolkit](https://github.com/EsonXie/dsh-agent-toolkit) — DSH toolkit with an agent registry, layered prompts, subagent delegation, Feishu bots and token-usage views; source builds use its workspace packages.
-- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) — Context Organization Layer for DSH/Cordis: persistent organizational Contexts (`ctx.col`), replaceable executors, verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`.
+- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) — Context Organization Layer for DSH/Cordis: persistent organizational Contexts (`ctx.col`), replaceable executors, verified 3-tier write-back, audited history, model-callable `col.create_context`. Zero deps besides peer `@deepseek-ai/cordis`. Install: npm i col-dsh-plugin.
 
 ## UI / Clients
 - [Miasakiii/dsh-miasaki](https://github.com/Miasakiii/dsh-miasaki) — Personal DSH (DeepSeek Harness) companion-project monorepo: desktop client (thin Tauri 2 shell + Win32 desktop pet + three themes) × Fleet multi-agent orchestration × Canvas plugin, three zero-coupled tracks.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This list collects the best of that ecosystem. Contributions welcome — see [Co
 npx @deepseek-ai/dsh web
 
 # Install a community plugin (from this list) into your profile
+- [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) — Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors (verified 3-tier write-back, audited history, model-callable `col.create_context` tool). Zero deps besides peer `@deepseek-ai/cordis`.
 dsh plugin --profile web add "github:owner/repo#main"
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This list collects the best of that ecosystem. Contributions welcome — see [Co
 npx @deepseek-ai/dsh web
 
 # Install a community plugin (from this list) into your profile
-- [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) — Context Organization Layer for DSH/Cordis: `ctx.col` provides persistent organizational Contexts with replaceable executors (verified 3-tier write-back, audited history, model-callable `col.create_context` tool). Zero deps besides peer `@deepseek-ai/cordis`.
 dsh plugin --profile web add "github:owner/repo#main"
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3153,7 +3153,7 @@ _多步 / 多 agent 调度器与输出聚合器。_
 - [dushaobindoudou/dsh-bots](https://github.com/dushaobindoudou/dsh-bots) — 接入外部 sdk-bots 网关的 DSH Web 工作台，提供机器人与群组聊天、MCP 管理及逐机器人工作区设置。
 - [GooDAnDReaDY/dsh-kanban](https://github.com/GooDAnDReaDY/dsh-kanban) — DSH 看板，提供本地任务、Gitea issue 同步、工作流列及与任务关联的 Agent 会话。 本次审查源码的 worktree 任务详情存在渲染缺陷。
 - [EsonXie/dsh-agent-toolkit](https://github.com/EsonXie/dsh-agent-toolkit) — 提供代理注册表、分层提示词、子代理委派、飞书机器人及 token 用量视图的 DSH 套件；源码构建依赖其 workspace 包。
-- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) —— 面向 DSH/Cordis 的 Context Organization Layer（编排/组织层）：`ctx.col` 提供持久组织化 Context（职位）、可替换执行器、验证过的三层写回、可审计历史，以及可被模型调用的 `col.create_context` 工具。除 peer 依赖 `@deepseek-ai/cordis` 外零依赖。
+- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) —— 面向 DSH/Cordis 的 Context Organization Layer（编排/组织层）：`ctx.col` 提供持久组织化 Context（职位）、可替换执行器、验证过的三层写回、可审计历史，以及可被模型调用的 `col.create_context` 工具。除 peer 依赖 `@deepseek-ai/cordis` 外零依赖。安装：npm i col-dsh-plugin.
 
 ## UI / 客户端
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3153,6 +3153,7 @@ _多步 / 多 agent 调度器与输出聚合器。_
 - [dushaobindoudou/dsh-bots](https://github.com/dushaobindoudou/dsh-bots) — 接入外部 sdk-bots 网关的 DSH Web 工作台，提供机器人与群组聊天、MCP 管理及逐机器人工作区设置。
 - [GooDAnDReaDY/dsh-kanban](https://github.com/GooDAnDReaDY/dsh-kanban) — DSH 看板，提供本地任务、Gitea issue 同步、工作流列及与任务关联的 Agent 会话。 本次审查源码的 worktree 任务详情存在渲染缺陷。
 - [EsonXie/dsh-agent-toolkit](https://github.com/EsonXie/dsh-agent-toolkit) — 提供代理注册表、分层提示词、子代理委派、飞书机器人及 token 用量视图的 DSH 套件；源码构建依赖其 workspace 包。
+- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) —— 面向 DSH/Cordis 的 Context Organization Layer（编排/组织层）：`ctx.col` 提供持久组织化 Context（职位）、可替换执行器、验证过的三层写回、可审计历史，以及可被模型调用的 `col.create_context` 工具。除 peer 依赖 `@deepseek-ai/cordis` 外零依赖。
 
 ## UI / 客户端
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3153,7 +3153,7 @@ _多步 / 多 agent 调度器与输出聚合器。_
 - [dushaobindoudou/dsh-bots](https://github.com/dushaobindoudou/dsh-bots) — 接入外部 sdk-bots 网关的 DSH Web 工作台，提供机器人与群组聊天、MCP 管理及逐机器人工作区设置。
 - [GooDAnDReaDY/dsh-kanban](https://github.com/GooDAnDReaDY/dsh-kanban) — DSH 看板，提供本地任务、Gitea issue 同步、工作流列及与任务关联的 Agent 会话。 本次审查源码的 worktree 任务详情存在渲染缺陷。
 - [EsonXie/dsh-agent-toolkit](https://github.com/EsonXie/dsh-agent-toolkit) — 提供代理注册表、分层提示词、子代理委派、飞书机器人及 token 用量视图的 DSH 套件；源码构建依赖其 workspace 包。
-- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) —— 面向 DSH/Cordis 的 Context Organization Layer（编排/组织层）：`ctx.col` 提供持久组织化 Context（职位）、可替换执行器、验证过的三层写回、可审计历史，以及可被模型调用的 `col.create_context` 工具。除 peer 依赖 `@deepseek-ai/cordis` 外零依赖。安装：npm i col-dsh-plugin.
+- [laodonge/col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin) —— 面向 DeepSeek Harness 的 Cordis 服务，提供持久上下文、执行器绑定、基于置信度标签的写回规则及事件历史；需手工注册到 profile，模型工具注册另见示例。
 
 ## UI / 客户端
 


### PR DESCRIPTION
Adds [col-dsh-plugin](https://github.com/laodonge/col-dsh-plugin): persistent organizational Contexts (`ctx.col`), replaceable executors, verified 3-tier write-back, audited history, model-callable tool. Real-load verified on DSH (see repo LAB-EVIDENCE). MIT, peer dep `@deepseek-ai/cordis` only.