### PR TITLE
Auto-add 34 DSH plugins (20260910 scan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ _DSH's core composition mechanism: a **profile** stacks bundle patch layers, the
 - [tianyuegithub/dsh-pactflow](https://github.com/tianyuegithub/dsh-pactflow) — DSH PactFlow (zero-pulse mode) external Profile Bundle.
 - [zachshi-ai/newmind](https://github.com/zachshi-ai/newmind) — Old-wisdom × new-intelligence lab: each classical school of thought solves one real AI problem. #1 zhizhi (知止) — a behavior-moderation layer for DeepSeek Harness inspired by the Tao Te Ching, aimed at agent reliability.
 - [chr003/dsh-subagent-model-picker](https://github.com/chr003/dsh-subagent-model-picker) — Separate per-session model and reasoning effort controls for DeepSeek Harness subagents.
+- [clearnature/dsh-math-proof](https://github.com/clearnature/dsh-math-proof) — Mathematical-proof agent preset for DeepSeek Harness using the Agda kernel as the proof checker, with compute-then-verify workflows and a long-horizon ledger of construction methods, evidence levels and refuted claims.
 
 ## Harnesses & Runtimes
 
@@ -922,6 +923,7 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [TencentCloudADP/Tencent-ADP-dsh-plugin](https://github.com/TencentCloudADP/Tencent-ADP-dsh-plugin) — DSH bundle for Tencent Cloud ADP model gateways, Hunyuan search, externally callable API/MCP plugins, skills and ADP app subagents; requires ADP credentials.
 - [yunxiyang/dsh-web-search-litellm](https://github.com/yunxiyang/dsh-web-search-litellm) — DSH web-search provider that sends Responses API web_search requests through a configured LiteLLM proxy.
 - [zzzmmmnn/dsh-openkapsel](https://github.com/zzzmmmnn/dsh-openkapsel) — OpenKapsel remote-workspace tools for DSH using local Python helpers; a bundle bootstrap installs the dedicated preset, whose tools and allowlist guard activate when selected.
+- [ice5kysl/dsh-why](https://github.com/ice5kysl/dsh-why) — Read-only failure-diagnostics CLI for DeepSeek Harness: checks plugin loader registration, engines.dsh compatibility and known breaking changes; zero dependencies and offline-capable.
 
 ## Security & Permissions
 
@@ -1555,6 +1557,7 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [xiazhenxin314-cpu/dsh-soul-memory](https://github.com/xiazhenxin314-cpu/dsh-soul-memory) — DSH file-backed cross-session memory with SOUL/MEMORY prompt injection, account/project logfiles, memory read/write tools, and a Cordis service; shipped as ESM without a build step.
 - [azazo1/dsh-copy-session-ref](https://github.com/azazo1/dsh-copy-session-ref) — Adds a DSH session-menu action that copies a session-reference mention to the clipboard.
 - [new-256/dsh-session-cleaner](https://github.com/new-256/dsh-session-cleaner) — DSH session trash manager with restore/purge actions, a web management page and configurable automatic expiry cleanup.
+- [biubiu23333333/dsh-memorix-panel](https://github.com/biubiu23333333/dsh-memorix-panel) — Memorix memory panel for the DSH Web GUI: browse projects and memories, view details, archive/restore and create memories; writes use the official Memorix CLI.
 
 ## Cost & Usage Tracking
 
@@ -2814,6 +2817,7 @@ _Long-running loop workflows: auto-research, deep-research, self-refine, iterati
 - [weibaohui/hermes-loop](https://github.com/weibaohui/hermes-loop) — DeepSeek Harness plugin: Hermes loop — review/curator automation and session-loop management.
 - [weibaohui/dsh-tasks](https://github.com/weibaohui/dsh-tasks) — DeepSeek Harness plugin: cron scheduled items — scheduled/immediate new-agent-session prompt submission with a full-screen management UI.
 - [TT-Wang/dsh-slice-agent-loop](https://github.com/TT-Wang/dsh-slice-agent-loop) — A drop-in DeepSeek Harness agent loop whose context engine is a bounded slice instead of a growing transcript.
+- [HiccupGeng/whale-notebook](https://github.com/HiccupGeng/whale-notebook) — DeepSeek Harness experience-learning plugin that extracts lessons from session logs and injects them into global rules after human confirmation.
 ## MCP Servers
 
 _Model Context Protocol servers that contribute tools / prompts / resources to DSH._
@@ -4403,6 +4407,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [oh-summy/dsh-remote-control](https://github.com/oh-summy/dsh-remote-control) — macOS/Linux scripts exposing DSH through Cloudflare Tunnel and a Caddy login gateway, with optional Feishu notifications.
 - [yangcanbin31-coder/dsh-nazuna-wallpaper-engine](https://github.com/yangcanbin31-coder/dsh-nazuna-wallpaper-engine) — Nazuna-themed derivative of elysia395/dsh-wallpaper-engine for DSH backgrounds, with purple glass styling and mascot controls; install from this repository rather than the upstream npm package.
 - [zijun-T/dsh-sidebar-remote](https://github.com/zijun-T/dsh-sidebar-remote) — SSH remote-workspace overlay for DSH Better Sidebar file operations, previews, terminals and Git; requires compatible dsh-better-sidebar and dsh-ssh plugins.
+- [nobu121/dsh-go](https://github.com/nobu121/dsh-go) — Native desktop window for DeepSeek Harness that wraps the official UI and shares the ~/.dsh directory with the CLI.
 
 ## Skills
 
@@ -4679,6 +4684,7 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [Fabian-698/dsh-upgrade-fix-012](https://github.com/Fabian-698/dsh-upgrade-fix-012) — Agent skill to diagnose and repair DeepSeek Harness 0.1.2-rc.x upgrade issues (UNKNOWN_MODEL, Session.events removal, and preset-missing resume), with a one-shot scan and dual verification gates.
 - [oxbshw/watch-skill](https://github.com/oxbshw/watch-skill) — Video, audio, and screen understanding with timestamped evidence; DeepWatch brings that evidence and independent verification into a workspace built on official DeepSeek Harness, via MCP, CLI, REST, and Web.
 - [siweimofang/dsh-plugin-zhishe-bikeng-qa](https://github.com/siweimofang/dsh-plugin-zhishe-bikeng-qa) — Manually registered DSH tool pack for renovation Q&A and inspection checklists, using keyword retrieval from user-supplied JSON knowledge files and rule-based risk labels.
+- [PerryLink/dsh-plugin-upgrade](https://github.com/PerryLink/dsh-plugin-upgrade) — Version-locked DeepSeek Harness plugin migration skill for 0.1.3-alpha.1 to 0.1.5-alpha.1, with a zero-dependency extension-seam scanner; packaged as a bundle skill and an npx CLI.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ _DSH's core composition mechanism: a **profile** stacks bundle patch layers, the
 
 _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime-level infrastructure (diagnostics, ops, session management, approval policies)._
 
+- [xingzhen199186/dsh-insight-tree](https://github.com/xingzhen199186/dsh-insight-tree) — DeepSeek Harness runtime observability and plugin diagnostics panel, combining profile, package, loader, and session evidence with installed-plugin controls and a standalone diagnostic page.
+- [YJLTF/dsh-thinktune](https://github.com/YJLTF/dsh-thinktune) — Ollama adapter for DeepSeek Harness with configurable reasoning-effort levels, four thinking-control strategies, and multimodal image input.
 - [782042369/dsh-model-compat-guard](https://github.com/782042369/dsh-model-compat-guard) — DSH (DeepSeek Harness) compatibility guard plugin: fixes reasoning-model compaction truncation, doomed sandbox-escalation fail-close, and missing tool description for GPT/Qwen/third-party models.
 - [kristol07/dsh-discussions-digest](https://github.com/kristol07/dsh-discussions-digest) — A small, evidence-first DeepSeek Harness plugin for recent activity in the official GitHub Discussions.
 - [MoriTang/dsh-plugins](https://github.com/MoriTang/dsh-plugins) — A collection of my DeepSeek Harness plugins.
@@ -1118,6 +1120,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 
 ## Session & Memory Management
 
+- [leetom314/dsh-tiered-memory](https://github.com/leetom314/dsh-tiered-memory) — Tiered memory for DeepSeek Harness with user, environment, and project layers, per-tier character budgets, routed queries, and explicit deletion.
 - [mill413/dsh-session-resume](https://github.com/mill413/dsh-session-resume) — Continue interrupted DeepSeek Harness tasks with one click.
 - [bvcvb/dsh-baize-rules](https://github.com/bvcvb/dsh-baize-rules) — Injects durable user-set must-do / must-not requirements into the model at conversation start.
 - [yihefeikong-rgb/dsh-cc-haha-dream](https://github.com/yihefeikong-rgb/dsh-cc-haha-dream) — DSH auto-dream plugin: background periodic session/memory review and consolidation/dedup (a port of CC-HAHA autoDream). Auto memory consolidation (dream) plugin for DeepSeek Harness, inspired by CC-HAHA.
@@ -2282,6 +2285,7 @@ _Generate presentations, decks, slide exports._
 - [chiang21fcb/dsh-ppt-guider](https://github.com/chiang21fcb/dsh-ppt-guider) — A DSH preset that makes the AI a PPT co-pilot rather than an autopilot: a six-step expert workflow supporting dual-path triggers, an SVG intermediate state, and PPT-safe constraints.
 ## Coding
 
+- [fhidalgodev/dsh-odoo-sdd](https://github.com/fhidalgodev/dsh-odoo-sdd) — Specification-driven Odoo development plugin for DeepSeek Harness, with phased workflows, module validation, and JSON-RPC verification against an existing Odoo instance.
 - [HorusJiang/dsh-map-tools](https://github.com/HorusJiang/dsh-map-tools) — Native map tools for DeepSeek Harness: driving/transit/walking/bicycling route planning, geocoding, reverse geocoding and POI search, powered by Amap with a free OSM/OSRM fallback.
 - [shengbinxu/dsh-open-code-review](https://github.com/shengbinxu/dsh-open-code-review) — A DeepSeek Harness (dsh) plugin for code review: open-code-review (ocr) delegation — deterministic file selection & rule resolution, reviewed by your own model (zero extra API key).
 - [magian1127/deepseek-harness-hashline](https://github.com/magian1127/deepseek-harness-hashline) — DeepSeek Harness hashline: hash-anchor editing.
@@ -2589,6 +2593,7 @@ _Code generation, refactoring, review, repo-level engineering plugins._
 
 _Reusable sub-agents / specialized agent packs runnable inside DSH._
 
+- [qigelunbiya/DSH-Patrol](https://github.com/qigelunbiya/DSH-Patrol) — Browser patrol and website inspection plugin for DeepSeek Harness: turns taught workflows into replayable runbooks with managed Chromium, screenshots, and checkpoints.
 - [wufufu770/d2d](https://github.com/wufufu770/d2d) — Three-ring parallel penetration-testing dsh plugin — discovery/deep/creative rings plus an independent verify loop, Kuzu graph blackboard shared state, multi-agent self-scheduling with per-role model policy and a self-learning knowledge brain. For authorized security testing only (SRC/CTF ranges/own assets).
 - [MajidAsghariTabrizi/universal-engineering-agent](https://github.com/MajidAsghariTabrizi/universal-engineering-agent) — Profile-agnostic, runnable implementation of the UEA 9-stage operating-kernel contract for coding agents (MIT).
 - [ndzuki/obsidian-task-runner](https://github.com/ndzuki/obsidian-task-runner) — Write requirements in Obsidian and let the AI handle the rest in a real repo: plan, implement, test, PR, and merge fully automated, with only "direction" and "acceptance" as the two human gates. Decisions become ADRs, lessons auto-consolidate back into the knowledge base, and an Agent Town pixel village visualizes concurrent sessions live. Go single binary + DSH plugin ecosystem.
@@ -3129,6 +3134,11 @@ _Multi-step / multi-agent schedulers and output aggregators._
 - [EsonXie/dsh-agent-toolkit](https://github.com/EsonXie/dsh-agent-toolkit) — DSH toolkit with an agent registry, layered prompts, subagent delegation, Feishu bots and token-usage views; source builds use its workspace packages.
 
 ## UI / Clients
+- [2021Heei/dsh-tts-flash](https://github.com/2021Heei/dsh-tts-flash) — Streaming reply read-aloud for DeepSeek Harness, with Edge TTS, OpenAI-compatible speech engines, and spoken waiting phrases.
+- [desanv01/deepseek-harness-desktop-app](https://github.com/desanv01/deepseek-harness-desktop-app) — Native Windows desktop shell for DeepSeek Harness using WebView2; launches a project-scoped DSH server and stops it when the window closes.
+- [mrSutivu/plugin-effort-slider](https://github.com/mrSutivu/plugin-effort-slider) — Reasoning-effort slider beside the DeepSeek Harness model picker, with discrete model-provided levels, theme support, and localized labels.
+- [vecnode/dsh-vn-plugins](https://github.com/vecnode/dsh-vn-plugins) — Personal DeepSeek Harness plugin pack for Windows, providing a docked file tree and a CodeMirror text editor for CLI web and desktop profiles.
+- [weilantianhai/dsh-command-skill-list](https://github.com/weilantianhai/dsh-command-skill-list) — Slash-command skill picker for DeepSeek Harness, with concise Chinese/English description translation, cached summaries, and custom notes.
 - [Miasakiii/dsh-miasaki](https://github.com/Miasakiii/dsh-miasaki) — Personal DSH (DeepSeek Harness) companion-project monorepo: desktop client (thin Tauri 2 shell + Win32 desktop pet + three themes) × Fleet multi-agent orchestration × Canvas plugin, three zero-coupled tracks.
 - [prgrmrwy/dsh-cockpit](https://github.com/prgrmrwy/dsh-cockpit) — Multi-device DeepSeek Harness cockpit: manage DSH on many machines from one page, jump straight into each device's native workbench (SSH loopback tunnel + read-only status aggregation, zero changes on the remote).
 - [softspark/dsh-process-console](https://github.com/softspark/dsh-process-console) — Processes tab for DeepSeek Harness: every agent and subagent of a conversation as a live console with paired tool requests and responses, installed as one profile bundle.
@@ -4396,6 +4406,7 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 ## Skills
 
 _Packaged task capabilities (markdown-based skills, tool packs)._
+- [Practice019/agent-skills](https://github.com/Practice019/agent-skills) — DSH user-level skill pack containing SKILL.md workflows for development, plugin authoring, research, document processing, and other tasks.
 - [Epiphany-Leon/dsh-skill-forge](https://github.com/Epiphany-Leon/dsh-skill-forge) — Multi-Agent collaborative skill forging system for DeepSeek Harness — distill conversational experience into verifiable, reusable Agent Skills.
 - [Guojiz/gitlearnos](https://github.com/Guojiz/gitlearnos) — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory.
 - [shenmituzi/img-share](https://github.com/shenmituzi/img-share) — DSH skill: share browser screenshots / local images in chat (thumbnail + fullscreen, phone-visible).

--- a/README.md
+++ b/README.md
@@ -924,6 +924,14 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [yunxiyang/dsh-web-search-litellm](https://github.com/yunxiyang/dsh-web-search-litellm) — DSH web-search provider that sends Responses API web_search requests through a configured LiteLLM proxy.
 - [zzzmmmnn/dsh-openkapsel](https://github.com/zzzmmmnn/dsh-openkapsel) — OpenKapsel remote-workspace tools for DSH using local Python helpers; a bundle bootstrap installs the dedicated preset, whose tools and allowlist guard activate when selected.
 - [ice5kysl/dsh-why](https://github.com/ice5kysl/dsh-why) — Read-only failure-diagnostics CLI for DeepSeek Harness: checks plugin loader registration, engines.dsh compatibility and known breaking changes; zero dependencies and offline-capable.
+- [Echan1208/DeepSeek-Harness-Setup](https://github.com/Echan1208/DeepSeek-Harness-Setup) — DeepSeek Harness Windows offline installer bundling all dependencies for network-free setup, with an office-productivity boost via Univer + ppt-master.
+- [fan56/dsh-cron](https://github.com/fan56/dsh-cron) — Cron scheduling for the DeepSeek Harness — bounded tasks with calendar & interval rules, delivered to live agents.
+- [fan56/dsh-model-sync](https://github.com/fan56/dsh-model-sync) — A dsh (DeepSeek Harness) Cordis plugin that keeps llm-pi-ai provider routes' model catalog in sync with the pi.dev gateway — written through the official settings seam, zero patches to dsh internals.
+- [idoall/dsh-update-status](https://github.com/idoall/dsh-update-status) — Read-only DeepSeek Harness Web version status and release-channel guidance plugin.
+- [Me-Maped/dsh-ask](https://github.com/Me-Maped/dsh-ask) — Direct terminal Q&A mode for DeepSeek Harness: persistent sessions, streaming output, and optional Fish/Bash/Zsh integration plus experimental PowerShell support.
+- [wesleyel/dsh-plugin-gpt-load](https://github.com/wesleyel/dsh-plugin-gpt-load) — DeepSeek Harness plugin: serve every gpt-load model from one provider group, each model on its own wire protocol (OpenAI Chat Completions or Anthropic Messages), synced from /api/models.
+- [yyh-001/dsh-launcher](https://github.com/yyh-001/dsh-launcher) — Lightweight Windows launcher for DeepSeek Harness: pick a version, launch dsh web.
+- [Zomcxj/dsh-desktop](https://github.com/Zomcxj/dsh-desktop) — Native desktop wrapper for the DeepSeek Harness — launches dsh web in a system tray window.
 
 ## Security & Permissions
 
@@ -1119,6 +1127,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [azazo1/dsh-write-protect](https://github.com/azazo1/dsh-write-protect) — DSH write/edit path protection with additional writable roots; sandboxed-command protection is supported through Linux bubblewrap and macOS Seatbelt.
 - [stadeummwt/dsh-supreme](https://github.com/stadeummwt/dsh-supreme) — Host-side governance bundle providing tool-call policy hooks, event logging, benchmark records, model-route selection, artifact validators, scoped memory selection, and workflow admission APIs; requires profile configuration.
 - [lt9/dsh-simple-auth](https://github.com/lt9/dsh-simple-auth) — DSH shared-key login gate with optional per-user session access lists and owner-managed session sharing.
+- [SodaZheng/dsh-totp](https://github.com/SodaZheng/dsh-totp) — An access-verification step for DeepSeek Harness, under your control.
 
 ## Session & Memory Management
 
@@ -1558,6 +1567,9 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [azazo1/dsh-copy-session-ref](https://github.com/azazo1/dsh-copy-session-ref) — Adds a DSH session-menu action that copies a session-reference mention to the clipboard.
 - [new-256/dsh-session-cleaner](https://github.com/new-256/dsh-session-cleaner) — DSH session trash manager with restore/purge actions, a web management page and configurable automatic expiry cleanup.
 - [biubiu23333333/dsh-memorix-panel](https://github.com/biubiu23333333/dsh-memorix-panel) — Memorix memory panel for the DSH Web GUI: browse projects and memories, view details, archive/restore and create memories; writes use the official Memorix CLI.
+- [AnLifeX/dsh-attention](https://github.com/AnLifeX/dsh-attention) — Reminder plugin for DeepSeek Harness: don't miss the moments that need you.
+- [NinjaSln-labs/dsh-context-compass](https://github.com/NinjaSln-labs/dsh-context-compass) — Session-health plugin for DeepSeek Harness: a real-data "continue vs. start fresh" context compass — header badge, /compass, the context_compass tool, and a multi-session overview panel.
+- [ohmejj/dsh-chat-archive](https://github.com/ohmejj/dsh-chat-archive) — Automatically archives DeepSeek Harness conversation logs.
 
 ## Cost & Usage Tracking
 
@@ -2591,6 +2603,9 @@ _Code generation, refactoring, review, repo-level engineering plugins._
 - [HaoyueQin/dsh-git-review](https://github.com/HaoyueQin/dsh-git-review) — DSH Git Review — a review tab + fenced git workbench for DeepSeek Harness: file tree, diffs, lane graph, and guarded git ops.
 - [Aealen/dsh-coding-workspace](https://github.com/Aealen/dsh-coding-workspace) — Coding workspace built on git worktrees for parallel development, adding cross-session collaboration primitives, a project-grouped sidebar, and a docked workspace panel — turns DSH's single-session UI into a multi-workspace parallel-development cockpit.
 - [zhaoxuejie/dsh-plugin-todo-scanner](https://github.com/zhaoxuejie/dsh-plugin-todo-scanner) — DeepSeek Harness TODO code scanner: recursively scans local code markers into structured lists, with status management, Markdown export and a TODO Radar sidebar panel.
+- [hanrr92/dsh-code-quote](https://github.com/hanrr92/dsh-code-quote) — Code quote / citation plugin for DeepSeek Harness (dsh).
+- [Shyboy0499/dsh-pr-watch](https://github.com/Shyboy0499/dsh-pr-watch) — DeepSeek Harness plugin: reports what changed in your authored pull requests since your last check — merged, closed, or gone stale.
+- [TheHeartFickle/dsh-conversation-folding](https://github.com/TheHeartFickle/dsh-conversation-folding) — DSH conversation-stream rendering enhancement: folds the process, keeps the substance — cleaner long conversations.
 
 ## Agents
 
@@ -2773,6 +2788,7 @@ _Reusable sub-agents / specialized agent packs runnable inside DSH._
 - [gongyijie85/dsh-agent-frugality](https://github.com/gongyijie85/dsh-agent-frugality) — Multi-agent frugality defense plugin for DeepSeek Harness: read-ledger dedup, compaction-immune rules, completion gate, cheap-review lane.
 - [GooDAnDReaDY/dsh-moa](https://github.com/GooDAnDReaDY/dsh-moa) — Mixture of Agents (MoA) plugin for DeepSeek Harness with /moa slash command, file workspaces, and Live Canvas integration.
 - [kvmem/dsh-super-advisor](https://github.com/kvmem/dsh-super-advisor) — DSH advisor tool for second opinions from a configured model, with editable request previews and per-call approval.
+- [cang6ng/dsh-life-assistant](https://github.com/cang6ng/dsh-life-assistant) — An extensible personal AI assistant built on DSH, starting with Chinook Music as its first user-data domain.
 
 ## Loops (Auto-Research, Self-Improve, etc.)
 
@@ -4685,6 +4701,8 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [oxbshw/watch-skill](https://github.com/oxbshw/watch-skill) — Video, audio, and screen understanding with timestamped evidence; DeepWatch brings that evidence and independent verification into a workspace built on official DeepSeek Harness, via MCP, CLI, REST, and Web.
 - [siweimofang/dsh-plugin-zhishe-bikeng-qa](https://github.com/siweimofang/dsh-plugin-zhishe-bikeng-qa) — Manually registered DSH tool pack for renovation Q&A and inspection checklists, using keyword retrieval from user-supplied JSON knowledge files and rule-based risk labels.
 - [PerryLink/dsh-plugin-upgrade](https://github.com/PerryLink/dsh-plugin-upgrade) — Version-locked DeepSeek Harness plugin migration skill for 0.1.3-alpha.1 to 0.1.5-alpha.1, with a zero-dependency extension-seam scanner; packaged as a bundle skill and an npx CLI.
+- [SCP-CN-1059/dsh-zhouli](https://github.com/SCP-CN-1059/dsh-zhouli) — Zhouli (Rites of Zhou) plugin: gives DeepSeek Harness a full-text search tool over the classic with stable coordinates (chapter.official-order), an official-post/duties index, cross-checked collation notes against two Kanripo editions, and an agent preset that acts per the Six Ministries' protocols. Citations are verifiable, never from memory.
+- [ybl2020/dsh-upgrade](https://github.com/ybl2020/dsh-upgrade) — DeepSeek Harness (dsh) upgrade-workflow skill: pre-upgrade assessment → user review & release → upgrade → post-upgrade verification, with mandatory backups, a rollback playbook, and third-party plugin/skill impact assessment. A reviewable, rollback-safe dsh upgrade skill.
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -925,6 +925,14 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [yunxiyang/dsh-web-search-litellm](https://github.com/yunxiyang/dsh-web-search-litellm) — 通过已配置的 LiteLLM 代理发送 Responses API web_search 请求的 DSH 网页搜索 provider。
 - [zzzmmmnn/dsh-openkapsel](https://github.com/zzzmmmnn/dsh-openkapsel) — 通过本地 Python 辅助程序提供 OpenKapsel 远程工作区工具；bundle 启动入口安装专用预设，选用该预设时才启用工具与白名单守卫。
 - [ice5kysl/dsh-why](https://github.com/ice5kysl/dsh-why) —— DeepSeek Harness 只读故障诊断 CLI：检查插件加载器注册、engines.dsh 兼容性及已知破坏性变更；零依赖，可离线使用。
+- [Echan1208/DeepSeek-Harness-Setup](https://github.com/Echan1208/DeepSeek-Harness-Setup) — DeepSeek Harness Windows 离线安装包：内置全部依赖，免联网安装运行，办公能力大幅增强（Univer + ppt-master）。
+- [fan56/dsh-cron](https://github.com/fan56/dsh-cron) — DeepSeek Harness 的 Cron 定时调度插件——基于日历与间隔规则的有界任务，投递给正在运行的 agent。
+- [fan56/dsh-model-sync](https://github.com/fan56/dsh-model-sync) — DeepSeek Harness (dsh) 的 Cordis 插件：通过官方 settings 接口同步 llm-pi-ai 供应商路由的模型目录，与 pi.dev 网关保持一致，零补丁改动 dsh 内部。
+- [idoall/dsh-update-status](https://github.com/idoall/dsh-update-status) — 只读的 DeepSeek Harness Web 版本状态与发布渠道指引插件。
+- [Me-Maped/dsh-ask](https://github.com/Me-Maped/dsh-ask) — 面向 DeepSeek Harness 的终端直接问答模式：支持持久会话、流式输出，以及可选的 Fish、Bash、Zsh 和实验性 PowerShell 集成。
+- [wesleyel/dsh-plugin-gpt-load](https://github.com/wesleyel/dsh-plugin-gpt-load) — DeepSeek Harness 插件：让 gpt-load 的所有模型统一走一个供应商组提供，每个模型各自使用对应协议（OpenAI Chat Completions 或 Anthropic Messages），并从 /api/models 同步。
+- [yyh-001/dsh-launcher](https://github.com/yyh-001/dsh-launcher) — DeepSeek Harness 轻量 Windows 启动器。选一个版本，启动 dsh web。
+- [Zomcxj/dsh-desktop](https://github.com/Zomcxj/dsh-desktop) — DeepSeek Harness 的原生桌面封装：在系统托盘窗口中启动 dsh web。
 
 ## 安全与权限
 
@@ -1125,6 +1133,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 - [azazo1/dsh-write-protect](https://github.com/azazo1/dsh-write-protect) — DSH write/edit 路径写保护与额外可写目录配置；沙箱命令的路径保护通过 Linux bubblewrap 和 macOS Seatbelt 实现。
 - [stadeummwt/dsh-supreme](https://github.com/stadeummwt/dsh-supreme) — 宿主侧治理套件，提供工具调用策略钩子、事件日志、基准记录、模型路由选择、产物校验、按作用域选择记忆及工作流准入 API；需按 profile 配置。
 - [lt9/dsh-simple-auth](https://github.com/lt9/dsh-simple-auth) — DSH 共享密钥登录门禁，支持可选的逐用户会话访问列表及由所有者管理的会话共享。
+- [SodaZheng/dsh-totp](https://github.com/SodaZheng/dsh-totp) — 为 DeepSeek Harness 加一道由你掌控的访问验证。
 
 ## 会话与记忆管理
 
@@ -1563,6 +1572,9 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [azazo1/dsh-copy-session-ref](https://github.com/azazo1/dsh-copy-session-ref) — 为 DSH 会话菜单添加复制操作，将会话引用 mention 写入剪贴板。
 - [new-256/dsh-session-cleaner](https://github.com/new-256/dsh-session-cleaner) — DSH 会话回收站管理器，提供恢复、彻底清除、网页管理页及可配置的到期自动清理。
 - [biubiu23333333/dsh-memorix-panel](https://github.com/biubiu23333333/dsh-memorix-panel) —— DSH Web GUI 的 Memorix 记忆面板：浏览项目与记忆、查看详情、归档/恢复及创建记忆；写入通过官方 Memorix CLI 完成。
+- [AnLifeX/dsh-attention](https://github.com/AnLifeX/dsh-attention) — dsh 提醒插件：别错过需要你的时刻。
+- [NinjaSln-labs/dsh-context-compass](https://github.com/NinjaSln-labs/dsh-context-compass) — DeepSeek Harness 会话健康插件：真实数据的「继续 vs 新开」上下文罗盘——头部徽章 / /compass / context_compass 工具 / 多会话一览面板。
+- [ohmejj/dsh-chat-archive](https://github.com/ohmejj/dsh-chat-archive) — 自动归档 DeepSeek Harness 对话记录。
 
 ## 成本与用量统计
 
@@ -2602,6 +2614,9 @@ _代码生成、重构、审查、仓库级工程插件。_
 - [HaoyueQin/dsh-git-review](https://github.com/HaoyueQin/dsh-git-review) — DSH Git Review — 审查标签页 + 围栏 Git 工作台：文件树、diff、lane graph、受保护的 git 操作。
 - [Aealen/dsh-coding-workspace](https://github.com/Aealen/dsh-coding-workspace) —— coding 工作台。以 git worktree 并行开发为地基，向上提供跨会话协作原语、项目分组侧栏与停靠式工作区面板，把 dsh 的单会话界面变成多工作区并行开发驶驶舱。
 - [zhaoxuejie/dsh-plugin-todo-scanner](https://github.com/zhaoxuejie/dsh-plugin-todo-scanner) —— DeepSeek Harness TODO 代码扫描插件：递归扫描本地代码标记，生成结构化清单，支持状态管理、Markdown 导出与侧边「TODO 雷达」面板。
+- [hanrr92/dsh-code-quote](https://github.com/hanrr92/dsh-code-quote) — 代码引用。
+- [Shyboy0499/dsh-pr-watch](https://github.com/Shyboy0499/dsh-pr-watch) — DeepSeek Harness 插件：报告你名下发起的 Pull Request 自上次查看以来的变化——已合并、已关闭或已过期（stale）。
+- [TheHeartFickle/dsh-conversation-folding](https://github.com/TheHeartFickle/dsh-conversation-folding) —— DSH 对话流渲染增强插件 —— 折叠过程，保留正文，长对话更清爽。
 
 ## Agent
 
@@ -2786,6 +2801,7 @@ _可在 DSH 内运行的可复用子 agent / 专用 agent 包。_
 - [gongyijie85/dsh-agent-frugality](https://github.com/gongyijie85/dsh-agent-frugality) —— 面向 DeepSeek Harness 的多代理节约防护插件：读取账本去重、抵抗压缩的规则、完成门控、平价复审通道。
 - [GooDAnDReaDY/dsh-moa](https://github.com/GooDAnDReaDY/dsh-moa) —— 面向 DeepSeek Harness 的 Mixture of Agents（MoA）插件，提供 /moa 斜杠命令、文件工作区与 Live Canvas 集成。
 - [kvmem/dsh-super-advisor](https://github.com/kvmem/dsh-super-advisor) — 向已配置模型征求第二意见的 DSH 顾问工具，支持编辑请求预览与逐次审批。
+- [cang6ng/dsh-life-assistant](https://github.com/cang6ng/dsh-life-assistant) — 基于 DSH 构建的可扩展个人 AI 助理，首个用户数据领域从 Chinook Music 起步。
 
 ## 循环（自动研究 / 自我改进等）
 
@@ -4684,6 +4700,8 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [oxbshw/watch-skill](https://github.com/oxbshw/watch-skill) —— 提供带时间戳证据的视频、音频与屏幕理解能力；DeepWatch 将这些证据与独立验证带入基于官方 DeepSeek Harness 的工作区，支持 MCP、CLI、REST 与 Web。
 - [siweimofang/dsh-plugin-zhishe-bikeng-qa](https://github.com/siweimofang/dsh-plugin-zhishe-bikeng-qa) — 需手工注册的 DSH 装修问答与验收清单工具包，基于用户提供的 JSON 知识文件做关键词检索，并以规则生成风险标签。
 - [PerryLink/dsh-plugin-upgrade](https://github.com/PerryLink/dsh-plugin-upgrade) —— 锁定版本的 DeepSeek Harness 插件迁移技能，面向 0.1.3-alpha.1 → 0.1.5-alpha.1，附零依赖扩展接缝扫描器；以 bundle skill 与 npx CLI 形式提供。
+- [SCP-CN-1059/dsh-zhouli](https://github.com/SCP-CN-1059/dsh-zhouli) — 《周礼》插件：给 DeepSeek Harness 提供带稳定坐标（篇序.职官序）的全文检索工具，含职官员额／职掌索引与 Kanripo 两本互校勘记，并附一套依六官法度行事的 agent 预设。引文可核，不凭记忆。
+- [ybl2020/dsh-upgrade](https://github.com/ybl2020/dsh-upgrade) — DeepSeek Harness (dsh) 升级流程技能：升级前评估 → 用户审核放行 → 升级 → 升级后验证。含强制备份、回滚手册、第三方插件与技能影响评估。A reviewable, rollback-safe dsh upgrade skill.
 
 ## 资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,6 +151,7 @@ _DSH 的核心组合机制：一个 **profile** 叠加各 bundle 的 patch 层�
 - [tianyuegithub/dsh-pactflow](https://github.com/tianyuegithub/dsh-pactflow) —— DSH PactFlow（零脉模式）外部 Profile Bundle。
 - [zachshi-ai/newmind](https://github.com/zachshi-ai/newmind) —— 老思想 × 新智能实验室：每门经典思想精确解决一个 AI 真实问题。#1 知止 zhizhi —— DeepSeek Harness 的行为节制层（道德经 × Agent 可靠性）。
 - [chr003/dsh-subagent-model-picker](https://github.com/chr003/dsh-subagent-model-picker) —— 为 DeepSeek Harness 子代理提供独立的按会话模型与推理强度控制。
+- [clearnature/dsh-math-proof](https://github.com/clearnature/dsh-math-proof) —— DeepSeek Harness 数学证明 Agent 预设：以 Agda 内核校验证明，采用先计算后验证的流程，并用长程台账记录对象构造方式、证据档位与被否证的判断。
 
 ## Harness 与运行时
 
@@ -923,6 +924,7 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [TencentCloudADP/Tencent-ADP-dsh-plugin](https://github.com/TencentCloudADP/Tencent-ADP-dsh-plugin) — 接入腾讯云 ADP 模型网关、混元搜索、可外部调用的 API/MCP 插件、技能及 ADP 应用子代理的 DSH 套件；需配置 ADP 凭据。
 - [yunxiyang/dsh-web-search-litellm](https://github.com/yunxiyang/dsh-web-search-litellm) — 通过已配置的 LiteLLM 代理发送 Responses API web_search 请求的 DSH 网页搜索 provider。
 - [zzzmmmnn/dsh-openkapsel](https://github.com/zzzmmmnn/dsh-openkapsel) — 通过本地 Python 辅助程序提供 OpenKapsel 远程工作区工具；bundle 启动入口安装专用预设，选用该预设时才启用工具与白名单守卫。
+- [ice5kysl/dsh-why](https://github.com/ice5kysl/dsh-why) —— DeepSeek Harness 只读故障诊断 CLI：检查插件加载器注册、engines.dsh 兼容性及已知破坏性变更；零依赖，可离线使用。
 
 ## 安全与权限
 
@@ -1560,6 +1562,7 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [xiazhenxin314-cpu/dsh-soul-memory](https://github.com/xiazhenxin314-cpu/dsh-soul-memory) — DSH 文件式跨会话记忆，提供 SOUL/MEMORY 提示注入、账号与项目日志、记忆读写工具和 Cordis 服务；以 ESM 交付，无需构建。
 - [azazo1/dsh-copy-session-ref](https://github.com/azazo1/dsh-copy-session-ref) — 为 DSH 会话菜单添加复制操作，将会话引用 mention 写入剪贴板。
 - [new-256/dsh-session-cleaner](https://github.com/new-256/dsh-session-cleaner) — DSH 会话回收站管理器，提供恢复、彻底清除、网页管理页及可配置的到期自动清理。
+- [biubiu23333333/dsh-memorix-panel](https://github.com/biubiu23333333/dsh-memorix-panel) —— DSH Web GUI 的 Memorix 记忆面板：浏览项目与记忆、查看详情、归档/恢复及创建记忆；写入通过官方 Memorix CLI 完成。
 
 ## 成本与用量统计
 
@@ -2830,6 +2833,7 @@ _长时运行的循环工作流：自动研究、深度调研、自我精炼、�
 - [BitDG/dsh-TableRAG](https://github.com/BitDG/dsh-TableRAG) — DeepSeek Harness 插件，将本地只读 TableRAG 目录暴露为原生工具。
 - [Modellix/dsh-modellix](https://github.com/Modellix/dsh-modellix) — 适配 Modellix Web Search 与 Web Fetch 的 DeepSeek Harness 插件。
 - [TT-Wang/dsh-slice-agent-loop](https://github.com/TT-Wang/dsh-slice-agent-loop) — 一个可直插的 DeepSeek Harness agent 循环，其上下文引擎是一个有边界的切片，而不是不断增长的对话记录。
+- [HiccupGeng/whale-notebook](https://github.com/HiccupGeng/whale-notebook) —— DeepSeek Harness 经验学习插件：从会话日志中提炼踩坑经验，经人工确认后注入全局规则。
 ## MCP Server
 
 _向 DSH 贡献工具 / prompt / 资源的 Model Context Protocol server。_
@@ -4400,6 +4404,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [oh-summy/dsh-remote-control](https://github.com/oh-summy/dsh-remote-control) — 通过 Cloudflare Tunnel 与 Caddy 登录网关提供 DSH 远程访问的 macOS/Linux 脚本，支持可选飞书通知。
 - [yangcanbin31-coder/dsh-nazuna-wallpaper-engine](https://github.com/yangcanbin31-coder/dsh-nazuna-wallpaper-engine) — 衍生自 elysia395/dsh-wallpaper-engine 的荠主题 DSH 背景插件，提供紫色玻璃风格与吉祥物控件；应从本仓库安装而非使用上游同名 npm 包。
 - [zijun-T/dsh-sidebar-remote](https://github.com/zijun-T/dsh-sidebar-remote) — 为 DSH Better Sidebar 的文件操作、预览、终端与 Git 提供 SSH 远程工作区扩展；依赖兼容的 dsh-better-sidebar 与 dsh-ssh 插件。
+- [nobu121/dsh-go](https://github.com/nobu121/dsh-go) —— DeepSeek Harness 原生桌面窗口：封装官方 UI，并与 CLI 共用 ~/.dsh 目录。
 
 ## Skill
 
@@ -4678,6 +4683,7 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [Fabian-698/dsh-upgrade-fix-012](https://github.com/Fabian-698/dsh-upgrade-fix-012) —— 诊断并修复 DeepSeek Harness 0.1.2-rc.x 升级问题的 Agent Skill：覆盖 UNKNOWN_MODEL、Session.events 移除和恢复会话时预设缺失，提供一次扫描与双重验证门。
 - [oxbshw/watch-skill](https://github.com/oxbshw/watch-skill) —— 提供带时间戳证据的视频、音频与屏幕理解能力；DeepWatch 将这些证据与独立验证带入基于官方 DeepSeek Harness 的工作区，支持 MCP、CLI、REST 与 Web。
 - [siweimofang/dsh-plugin-zhishe-bikeng-qa](https://github.com/siweimofang/dsh-plugin-zhishe-bikeng-qa) — 需手工注册的 DSH 装修问答与验收清单工具包，基于用户提供的 JSON 知识文件做关键词检索，并以规则生成风险标签。
+- [PerryLink/dsh-plugin-upgrade](https://github.com/PerryLink/dsh-plugin-upgrade) —— 锁定版本的 DeepSeek Harness 插件迁移技能，面向 0.1.3-alpha.1 → 0.1.5-alpha.1，附零依赖扩展接缝扫描器；以 bundle skill 与 npx CLI 形式提供。
 
 ## 资源
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -156,6 +156,8 @@ _DSH 的核心组合机制：一个 **profile** 叠加各 bundle 的 patch 层�
 
 _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运行时级基建（诊断、运维、会话管理、审批策略）。_
 
+- [xingzhen199186/dsh-insight-tree](https://github.com/xingzhen199186/dsh-insight-tree) —— DeepSeek Harness 运行可观测与插件诊断面板，汇总 profile、安装包、加载器及会话信息，提供已安装插件操作和独立诊断页。
+- [YJLTF/dsh-thinktune](https://github.com/YJLTF/dsh-thinktune) —— DeepSeek Harness 的 Ollama 适配器，支持可配置推理强度档位、四种思考控制策略和多模态图片输入。
 - [782042369/dsh-model-compat-guard](https://github.com/782042369/dsh-model-compat-guard) —— DSH（DeepSeek Harness）兼容性守卫插件：修复推理模型压缩截断问题、危险的沙箱越权 fail-close 缺陷，以及 GPT/Qwen/第三方模型缺失工具描述的问题。
 - [kristol07/dsh-discussions-digest](https://github.com/kristol07/dsh-discussions-digest) —— 一个小型的、以证据为先的 DeepSeek Harness 插件，用于追踪官方 GitHub Discussions 的最新动态。
 - [MoriTang/dsh-plugins](https://github.com/MoriTang/dsh-plugins) —— 个人 DeepSeek Harness 插件合集。
@@ -1124,6 +1126,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 
 ## 会话与记忆管理
 
+- [leetom314/dsh-tiered-memory](https://github.com/leetom314/dsh-tiered-memory) —— DeepSeek Harness 分层记忆插件，划分用户、环境与项目三层，支持各层字符预算、查询路由和显式删除。
 - [mill413/dsh-session-resume](https://github.com/mill413/dsh-session-resume) —— 一键继续被中断的 DeepSeek Harness 任务。
 - [bvcvb/dsh-baize-rules](https://github.com/bvcvb/dsh-baize-rules) —— 在会话开始时向模型注入用户设定的“必须做 / 不能做”持久要求。
 - [yihefeikong-rgb/dsh-cc-haha-dream](https://github.com/yihefeikong-rgb/dsh-cc-haha-dream) —— DSH 自动做梦插件：后台定期回顾会话与记忆整合去重（复刻 CC-HAHA autoDream）· Auto memory consolidation (dream) plugin for DeepSeek Harness, inspired by CC-HAHA.
@@ -2295,6 +2298,7 @@ _生成演示文稿、幻灯片、导出 PPT。_
 - [chiang21fcb/dsh-ppt-guider](https://github.com/chiang21fcb/dsh-ppt-guider) — 让 AI 做 PPT 的副驶，而非自动驶驶。DSH 预设，六步专家工作流，支持双路径触发，SVG 中间态 + PPT-safe 约束。
 ## 写代码
 
+- [fhidalgodev/dsh-odoo-sdd](https://github.com/fhidalgodev/dsh-odoo-sdd) —— DeepSeek Harness 的规格驱动 Odoo 开发插件，提供分阶段工作流、模块校验，以及面向已有 Odoo 实例的 JSON-RPC 验证。
 - [HorusJiang/dsh-map-tools](https://github.com/HorusJiang/dsh-map-tools) — DeepSeek Harness 原生地图工具：驾车/公交/步行/骑行路线规划、地理编码、逆地理编码与 POI 搜索，高德数据为主，OSM/OSRM 免费兜底。
 - [shengbinxu/dsh-open-code-review](https://github.com/shengbinxu/dsh-open-code-review) — 面向 DeepSeek Harness (dsh) 的代码审查插件：open-code-review（ocr）委托——确定性文件选择与规则解析，由你自己的模型审查（无需额外 API Key）。
 - [magian1127/deepseek-harness-hashline](https://github.com/magian1127/deepseek-harness-hashline) — DeepSeek Harness hashline — 哈希锚点编辑。
@@ -2600,6 +2604,7 @@ _代码生成、重构、审查、仓库级工程插件。_
 
 _可在 DSH 内运行的可复用子 agent / 专用 agent 包。_
 
+- [qigelunbiya/DSH-Patrol](https://github.com/qigelunbiya/DSH-Patrol) —— DeepSeek Harness 网页巡检插件：将教学流程固化为可重放的操作手册，支持受管 Chromium、截图和检查点。
 - [wufufu770/d2d](https://github.com/wufufu770/d2d) —— 三环并行渗透测试 dsh 插件 —— discovery/deep/creative 三环 + 独立 verify 闭环，Kuzu 图黑板共享状态，多 agent 自调度、按角色模型策略、自学习知识脑。仅用于授权安全测试（SRC/靶场/自有资产）。
 - [MajidAsghariTabrizi/universal-engineering-agent](https://github.com/MajidAsghariTabrizi/universal-engineering-agent) —— UEA 9 阶段编码代理操作内核的可运行实现（MIT）。
 - [ndzuki/obsidian-task-runner](https://github.com/ndzuki/obsidian-task-runner) —— 在 Obsidian 写需求，AI 在真实仓库里完成剩下的一切。计划、实现、测试、PR、合并全自动；只有「方向」和「验收」两扇人门。决策 ADR 化，踩坑自动沉淀回知识库；Agent Town 像素小镇实时监控并发会话。Go 单二进制 + DSH 插件生态。
@@ -3157,6 +3162,11 @@ _多步 / 多 agent 调度器与输出聚合器。_
 ## UI / 客户端
 
 _DSH 的桌面、网页、终端或编辑器前端。_
+- [2021Heei/dsh-tts-flash](https://github.com/2021Heei/dsh-tts-flash) —— DeepSeek Harness 流式回复朗读插件，支持 Edge TTS、OpenAI 兼容语音引擎和思考等待期语音短语。
+- [desanv01/deepseek-harness-desktop-app](https://github.com/desanv01/deepseek-harness-desktop-app) —— 基于 WebView2 的 DeepSeek Harness 原生 Windows 桌面外壳，启动项目专属 DSH 服务，并在窗口关闭时停止服务。
+- [mrSutivu/plugin-effort-slider](https://github.com/mrSutivu/plugin-effort-slider) —— 在 DeepSeek Harness 模型选择器旁添加推理强度滑块，支持模型提供的离散档位、主题适配和多语言标签。
+- [vecnode/dsh-vn-plugins](https://github.com/vecnode/dsh-vn-plugins) —— 面向 Windows 的个人 DeepSeek Harness 插件包，为 CLI Web 与桌面 profile 提供停靠式文件树和 CodeMirror 文本编辑器。
+- [weilantianhai/dsh-command-skill-list](https://github.com/weilantianhai/dsh-command-skill-list) —— DeepSeek Harness 斜杠命令技能选择插件，支持中英文描述精简翻译、摘要缓存和自定义备注。
 - [Miasakiii/dsh-miasaki](https://github.com/Miasakiii/dsh-miasaki) —— Miasaki 专属的 DSH（DeepSeek Harness）周边项目 monorepo：桌面端（Tauri 2 薄壳 + Win32 桌宠 + 三主题）× Fleet 多 Agent 编排 × Canvas 画布插件，三线零耦合。
 - [prgrmrwy/dsh-cockpit](https://github.com/prgrmrwy/dsh-cockpit) —— 多设备 DeepSeek Harness 驶驶餦：一个页面管理多台机器上的 DSH，选中设备直接用它原生的工作台（SSH 回环隆道 + 只读状态聚合，远端零改造）。
 - [softspark/dsh-process-console](https://github.com/softspark/dsh-process-console) —— DeepSeek Harness 的 Processes 选项卡：把一个对话中每个 agent 与 subagent 变成实时控制台，工具请求与响应一一对应，以单个 profile bundle 安装。
@@ -4393,6 +4403,7 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 ## Skill
 
 _打包好的任务能力（基于 markdown 的 skill、工具包）。_
+- [Practice019/agent-skills](https://github.com/Practice019/agent-skills) —— DSH 用户级技能包，包含开发、插件编写、调研、文档处理等任务的 SKILL.md 工作流。
 - [Epiphany-Leon/dsh-skill-forge](https://github.com/Epiphany-Leon/dsh-skill-forge) —— 面向 DeepSeek Harness 的多 Agent 协作式 skill 锻造系统——把对话中积类的经验提炼为可验证、可复用的 Agent Skill。
 - [Guojiz/gitlearnos](https://github.com/Guojiz/gitlearnos) —— Git 原生的 AI 学习操作系统，内建 GitLearnOS 专属的 DeepSeek Harness 面板、针对性练习、本地 RAG 与学习者自主的记忆。
 - [shenmituzi/img-share](https://github.com/shenmituzi/img-share) —— DSH skill：在对话中分享浏览器截图/本地图片（缩略图 + 全屏，手机可见）。


### PR DESCRIPTION
自动扫描收录：新增社区 DSH 插件（去重后）。仅改 README.md / README.zh-CN.md。由每日扫描自动化生成，PR 巡检会自动核验链接真实性与格式后合并。

本次（第三批）新增 18 条，剔除 0 条，跳过 0 条（候选清单 18 条均未与当前 README 重复）。

第三批新增：
- AnLifeX/dsh-attention — Session & Memory Management
- cang6ng/dsh-life-assistant — Agents
- Echan1208/DeepSeek-Harness-Setup — Harnesses & Runtimes
- fan56/dsh-cron — Harnesses & Runtimes
- fan56/dsh-model-sync — Harnesses & Runtimes
- hanrr92/dsh-code-quote — Coding
- idoall/dsh-update-status — Harnesses & Runtimes
- Me-Maped/dsh-ask — Harnesses & Runtimes
- NinjaSln-labs/dsh-context-compass — Session & Memory Management
- ohmejj/dsh-chat-archive — Session & Memory Management
- SCP-CN-1059/dsh-zhouli — Skills
- Shyboy0499/dsh-pr-watch — Coding
- SodaZheng/dsh-totp — Security & Permissions
- TheHeartFickle/dsh-conversation-folding — Coding
- wesleyel/dsh-plugin-gpt-load — Harnesses & Runtimes
- ybl2020/dsh-upgrade — Skills
- yyh-001/dsh-launcher — Harnesses & Runtimes
- Zomcxj/dsh-desktop — Harnesses & Runtimes

已核验：本次双语各新增 18 条、无条目删除、候选 URL 不重复；复用同日收录分支和 PR，保留第一、二批提交（11+6=16 条，其中 1 条已由其他 PR 先行收录到 main，故此前净新增 16 条）。累计本 PR 相对 main 双语各新增 16 + 18 = 34 条。本轮不合并 PR，也不启用自动合并。