### PR TITLE
Add dsh-upgrade skill (rollback-safe dsh upgrade flow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4669,6 +4669,7 @@ _Packaged task capabilities (markdown-based skills, tool packs)._
 - [Fabian-698/dsh-upgrade-fix-012](https://github.com/Fabian-698/dsh-upgrade-fix-012) — Agent skill to diagnose and repair DeepSeek Harness 0.1.2-rc.x upgrade issues (UNKNOWN_MODEL, Session.events removal, and preset-missing resume), with a one-shot scan and dual verification gates.
 - [oxbshw/watch-skill](https://github.com/oxbshw/watch-skill) — Video, audio, and screen understanding with timestamped evidence; DeepWatch brings that evidence and independent verification into a workspace built on official DeepSeek Harness, via MCP, CLI, REST, and Web.
 - [siweimofang/dsh-plugin-zhishe-bikeng-qa](https://github.com/siweimofang/dsh-plugin-zhishe-bikeng-qa) — Manually registered DSH tool pack for renovation Q&A and inspection checklists, using keyword retrieval from user-supplied JSON knowledge files and rule-based risk labels.
+- [ybl2020/dsh-upgrade](https://github.com/ybl2020/dsh-upgrade) — Reviewable, rollback-safe DeepSeek Harness upgrade skill: pre-upgrade assessment, user approval gate, mandatory backup with rollback manual, and evidence-driven post-upgrade verification.
 
 ## Resources
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4668,6 +4668,7 @@ _打包好的任务能力（基于 markdown 的 skill、工具包）。_
 - [Fabian-698/dsh-upgrade-fix-012](https://github.com/Fabian-698/dsh-upgrade-fix-012) —— 诊断并修复 DeepSeek Harness 0.1.2-rc.x 升级问题的 Agent Skill：覆盖 UNKNOWN_MODEL、Session.events 移除和恢复会话时预设缺失，提供一次扫描与双重验证门。
 - [oxbshw/watch-skill](https://github.com/oxbshw/watch-skill) —— 提供带时间戳证据的视频、音频与屏幕理解能力；DeepWatch 将这些证据与独立验证带入基于官方 DeepSeek Harness 的工作区，支持 MCP、CLI、REST 与 Web。
 - [siweimofang/dsh-plugin-zhishe-bikeng-qa](https://github.com/siweimofang/dsh-plugin-zhishe-bikeng-qa) — 需手工注册的 DSH 装修问答与验收清单工具包，基于用户提供的 JSON 知识文件做关键词检索，并以规则生成风险标签。
+- [ybl2020/dsh-upgrade](https://github.com/ybl2020/dsh-upgrade) —— 可审核、可回滚、有证据的 DeepSeek Harness 升级流程技能：升级前评估、用户审核放行、强制备份与回滚手册、升级后证据驱动验证。
 
 ## 资源
 


### PR DESCRIPTION
## What are you adding?

- **Name:** dsh-upgrade
- **Link:** https://github.com/ybl2020/dsh-upgrade
- **Category:** Skills
- **One-line description:** Reviewable, rollback-safe DeepSeek Harness upgrade skill: pre-upgrade assessment, user approval gate, mandatory backup with rollback manual, and evidence-driven post-upgrade verification.

## Why it's useful

Upgrading DSH has a few non-obvious failure modes that this skill addresses:

- DSH does not enforce peer dependencies, so third-party plugins with out-of-range peers upgrade silently and break at runtime.
- Third-party **plugins** and third-party **skills** are independent sets — auditing only plugins misses every skill.
- npm 11+ silently skips native-module install scripts (e.g. `node-pty`), so compiled artifacts can go missing without an error.
- `dsh web` requires an in-memory token: requests without it return **401**, not 200, so older "expect 200" checks misreport success as failure.
- `dsh --profile web --dump-config` is **not** read-only — it writes `cordis.yml`.
- Prerelease semver rules mean `^0.1.2-rc.1` does not satisfy `0.1.5-rc.1`, so almost every third-party plugin reports an unsatisfied peer during an rc-to-rc upgrade.

The skill puts a user approval gate before the upgrade, makes backup unconditional, and verifies afterward with concrete evidence (PID change, process start time, and the native modules actually loaded by the running process via `lsof`).

## Checklist

- [x] The repo carries the `#dsh` GitHub topic
- [x] I edited **both** `README.md` and `README.zh-CN.md`
- [x] Entry follows the format: `- [Name](url) — description.`
- [x] Description is factual and hype-free
- [x] The project is real, working, and publicly accessible

## Notes for the maintainer

- This PR is a **pure insertion**: 2 added lines, 0 removed, and it touches only the two README files.
- The skill is MIT licensed and was written from a real `0.1.2-rc.1` → `0.1.5-rc.1` upgrade, with every documented pitfall backed by an on-machine test.
