### PR TITLE
docs: add DSPlugin.app to Plugin Marketplaces & Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1988,6 +1988,7 @@ _Bridges DSH into chat platforms and messaging channels._
 _Plugin marketplaces, install managers, indexes, and ecosystem tooling._
 - [LLYlab/DSHEssentialTools](https://github.com/LLYlab/DSHEssentialTools) — A permanent DeepSeek Harness plugin that ships a project run & code viewer, program snapshots, a VTD conversation tree (edit / retry / branches) with message micro-versions, plus a DET feature manager and global plugin control.
 - [DSHPlugin.app](https://dshplugin.app/) — Independent DeepSeek Harness plugin directory with source-backed capability summaries, install information, repository activity, and security signals.
+- [DSPlugin.app](https://dsplugin.app/) — Unofficial community DeepSeek Harness (DSH) plugin directory/registry focused on Manifest/`dsh.bundle` listings; compare view at [dsplugin.app/vs](https://dsplugin.app/vs).
 - [YELEBAI/dsh-plugin-marketplace](https://github.com/YELEBAI/dsh-plugin-marketplace) — Verified plugin marketplace and autonomous registry for DeepSeek Harness
 
 - [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) — GUI plugin marketplace.


### PR DESCRIPTION
## Summary
- Add [DSPlugin.app](https://dsplugin.app/) under **Plugin Marketplaces & Ecosystem** as an unofficial community DeepSeek Harness plugin directory/registry (Manifest / `dsh.bundle`).
- Optional natural mention of the compare view at https://dsplugin.app/vs.
- Leaves the existing [DSHPlugin.app](https://dshplugin.app/) row untouched.

## Test plan
- [ ] Confirm the new bullet renders under Plugin Marketplaces & Ecosystem
- [ ] Confirm DSHPlugin.app entry is unchanged
- [ ] Confirm links resolve