### PR TITLE
Add jacjackai/dsh-control to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -4483,7 +4483,6 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 ## Skills
 
 _Packaged task capabilities (markdown-based skills, tool packs)._
-
 - [jacjackai/dsh-control](https://github.com/jacjackai/dsh-control) — DSH skill: let AI agents operate DSH itself via the official HTTP RPC — workspace/session control, task-card dispatch with acceptance criteria, resident workstations with blocking wait, and multi-model fan-out review with per-seat model assignment.
 - [Practice019/agent-skills](https://github.com/Practice019/agent-skills) — DSH user-level skill pack containing SKILL.md workflows for development, plugin authoring, research, document processing, and other tasks.
 - [Epiphany-Leon/dsh-skill-forge](https://github.com/Epiphany-Leon/dsh-skill-forge) — Multi-Agent collaborative skill forging system for DeepSeek Harness — distill conversational experience into verifiable, reusable Agent Skills.

--- a/README.md
+++ b/README.md
@@ -4483,6 +4483,8 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 ## Skills
 
 _Packaged task capabilities (markdown-based skills, tool packs)._
+
+- [jacjackai/dsh-control](https://github.com/jacjackai/dsh-control) — DSH skill: let AI agents operate DSH itself via the official HTTP RPC — workspace/session control, task-card dispatch with acceptance criteria, resident workstations with blocking wait, and multi-model fan-out review with per-seat model assignment.
 - [Practice019/agent-skills](https://github.com/Practice019/agent-skills) — DSH user-level skill pack containing SKILL.md workflows for development, plugin authoring, research, document processing, and other tasks.
 - [Epiphany-Leon/dsh-skill-forge](https://github.com/Epiphany-Leon/dsh-skill-forge) — Multi-Agent collaborative skill forging system for DeepSeek Harness — distill conversational experience into verifiable, reusable Agent Skills.
 - [Guojiz/gitlearnos](https://github.com/Guojiz/gitlearnos) — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory.


### PR DESCRIPTION
收录 [jacjackai/dsh-control](https://github.com/jacjackai/dsh-control)：让 AI Agent 通过 DSH 官方 HTTP RPC 操作宿主自身——工作区/会话控制、任务卡派工（结构化验收标准）、常驻工位闭环（find --create → dispatch → wait）、多模型扇出评审（fanout --models 每席指定模型家族）。已验证 DSH 0.1.1-rc.2，社区 skill 非官方。