### PR TITLE
Add hutao562/dsh-remote-dsh (Harnesses & Runtimes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [lemoncat7/dsh-ssh](https://github.com/lemoncat7/dsh-ssh) — SSH sessions, SFTP, terminals, proxies and port forwarding for DeepSeek Harness.
 - [tingao/dsh-peaktime-clock](https://github.com/tingao/dsh-peaktime-clock) — Peak-time clock plugin for DeepSeek Harness (deepseek-harness, dsh-plugin).
 - [chai1110/dsh-ssh-remote](https://github.com/chai1110/dsh-ssh-remote) — Multi-machine remote workspace plugin for DeepSeek Harness: connect to several servers at once, with the agent viewing/editing/executing files directly on the remotes. Adapted from flymysql/dsh-remote (MIT) for 0.1.1-rc.2.
+- [hutao562/dsh-remote-dsh](https://github.com/hutao562/dsh-remote-dsh) — Adds a row at the top of the sidebar that switches the whole Web GUI to another DSH host reached over a loopback port, with that host's session state on the row (running, unread activity, or waiting for your answer).
 - [IceApriler/dsh-remote-mobile](https://github.com/IceApriler/dsh-remote-mobile) — Remote & mobile security gateway plugin for DeepSeek Harness (DSH): zero-modification safe exposure over LAN and Tailscale, QR-code auth, RSA encryption, and brute-force defense.
 - [ma-harness/ma-harness.rs](https://github.com/ma-harness/ma-harness.rs) — A Rust reimplementation developed based on deepseek-harness.
 - [songoao25/dsh-plugin-guardian](https://github.com/songoao25/dsh-plugin-guardian) — Safe uninstall with snapshot rollback for DeepSeek Harness plugins — clean residue, health check, no command line.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,6 +174,7 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [lemoncat7/dsh-ssh](https://github.com/lemoncat7/dsh-ssh) —— 面向 DeepSeek Harness 的 SSH 会话、SFTP、终端、代理与端口转发插件。
 - [tingao/dsh-peaktime-clock](https://github.com/tingao/dsh-peaktime-clock) —— 面向 DeepSeek Harness 的峰时时钟插件（打有 deepseek-harness、dsh-plugin 标签）。
 - [chai1110/dsh-ssh-remote](https://github.com/chai1110/dsh-ssh-remote) —— DeepSeek Harness SSH 远程工作区插件（多机并行）：同时连接多台服务器，Agent 直接查看/编辑/执行远程文件。基于 flymysql/dsh-remote (MIT) 适配 0.1.1-rc.2。
+- [hutao562/dsh-remote-dsh](https://github.com/hutao562/dsh-remote-dsh) —— 在侧边栏顶部加一行，点击后整页切换成另一台 DSH 主机的 Web GUI（通过回环端口访问），并在该行显示那台主机的会话状态（运行中、有新活动、正等你回答）。
 - [IceApriler/dsh-remote-mobile](https://github.com/IceApriler/dsh-remote-mobile) —— DeepSeek Harness 远程与移动端安全网关插件：零修改 DSH 底层代码，安全开放局域网与 Tailscale 连接，支持二维码扫码认证、RSA 加密与防暴力破解。
 - [ma-harness/ma-harness.rs](https://github.com/ma-harness/ma-harness.rs) —— 基于 deepseek-harness 开发的 Rust 版本实现。
 - [songoao25/dsh-plugin-guardian](https://github.com/songoao25/dsh-plugin-guardian) —— 面向 DeepSeek Harness 插件的安全卸载工具：快照回滚、清理残留、健康检查，无需命令行。


### PR DESCRIPTION
Adds one entry to **Harnesses & Runtimes** / **Harness 与运行时** in both `README.md` and `README.zh-CN.md`, right after `chai1110/dsh-ssh-remote` and before `IceApriler/dsh-remote-mobile` (alphabetical by owner).

**Plugin:** [hutao562/dsh-remote-dsh](https://github.com/hutao562/dsh-remote-dsh) — a row at the top of the sidebar; clicking it switches the whole page to another DSH host's Web GUI, reached over a loopback port, and the row carries that host's session state (running / unread activity / waiting for your answer).

**Checklist from CONTRIBUTING:**

- The repository carries the `dsh` GitHub topic (along with `dsh-plugin`, `deepseek-harness`).
- Both files are edited and stay in sync; the diff is **pure insertions** — `git diff --numstat` is `1 0` for each file, so no neighbour row is touched.
- Category: I put it beside the other remote/sidebar plugins (`chai1110/dsh-ssh-remote`, `Blank-not-black/dsh-remote-plugin`, `IceApriler/dsh-remote-mobile`). Happy to move it if you would rather have a UI/Clients section for it in the English file, which currently has no such section.
- Description is factual and hype-free.
- Published on npm as [`dsh-remote-dsh`](https://www.npmjs.com/package/dsh-remote-dsh) (0.1.1), so an install is `dsh plugin --profile web add dsh-remote-dsh`.
