### PR TITLE
Auto-add 27 DSH plugins (20260912 scan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,6 +958,16 @@ _DeepSeek-native or DeepSeek-first agent harnesses / coding agents, plus runtime
 - [andrepontesmelo/dsh-model-router](https://github.com/andrepontesmelo/dsh-model-router) — DSH plugin: virtual model ids backed by pluggable routing algorithms (priority, round-robin) over real provider candidates, with transparent failover.
 - [twilightt1/dsh-llm-chatgpt-web](https://github.com/twilightt1/dsh-llm-chatgpt-web) — ChatGPT Web as a DeepSeek Harness provider — an owned Chromium daemon driving Temporary Chat, no API key required.
 - [SiriusWJ/dsh-restart-btn](https://github.com/SiriusWJ/dsh-restart-btn) — One-click restart button in the settings page: restarts dsh web through the desktop-launcher mechanism (node + lib/bin.js, log redirection, TCP readiness polling), and fixes silent scheduled-task failures on non-ASCII paths.
+- [bpc-oss/dsh-video-input-mod](https://github.com/bpc-oss/dsh-video-input-mod) — Native video input for DSH Desktop — kernel patches (P17-P25), tools and docs. The agent auto-reads video from disk; capability-gated native decode vs. frame extraction.
+- [imMamdouhaboammar/get-fable](https://github.com/imMamdouhaboammar/get-fable) — Make the model you already use work more like a frontier model: better planning, persistent context, skills, hooks, failure handling, and verification.
+- [jiale-li-orion/meshfin](https://github.com/jiale-li-orion/meshfin) — One agent across many devices — a multi-device capability runtime and personal workbench for persistent agents, built on DeepSeek Harness.
+- [lengmoXXL/dsh-remote-ssh-worktree](https://github.com/lengmoXXL/dsh-remote-ssh-worktree) — Runs DSH's file, shell, and terminal tools inside a git worktree on a remote machine over SSH; the remote agent installs itself as a static Rust binary from GitHub Releases, listens on a random loopback port, and updates with the plugin.
+- [MurasakiIzumi/dsh-quake-alert](https://github.com/MurasakiIzumi/dsh-quake-alert) — Real-time Japanese earthquake, EEW, tsunami and JMA weather alerts for DeepSeek Harness (DSH) — matched against your watch regions and thresholds.
+- [wly8691-jpg/dsh-office-com](https://github.com/wly8691-jpg/dsh-office-com) — DSH plugin: COM-driven real Office automation (VBA / pivot tables / recalculation / layout).
+- [xiaomao49/dsh-model-probe](https://github.com/xiaomao49/dsh-model-probe) — DeepSeek Harness plugin that audits and corrects llm-pi-ai model capability declarations by probing the endpoint itself: out-of-range maxTokens, contextWindow, reasoning levels, image input.
+- [Yinxe/deepseek-harness-plugins](https://github.com/Yinxe/deepseek-harness-plugins) — DeepSeek Harness (DSH) plugins monorepo (pnpm + TypeScript).
+- [Yunado/dsh-qwen38-local-qol](https://github.com/Yunado/dsh-qwen38-local-qol) — DSH QoL plugin for the local Qwen3.8 line (27B/Flash-Next): per-request thinking budgets, a compaction backend that stops burning the output cap on thinking, and a settings tab.
+- [zhengjy01/dsh-restart](https://github.com/zhengjy01/dsh-restart) — One-click restart for DeepSeek Harness: a web button (plus a dsh_restart agent tool) hands the relaunch to a detached helper, the page reconnects by itself, and a recovery console shows boot errors when the new host fails.
 
 ## Security & Permissions
 
@@ -1164,6 +1174,7 @@ _Permission rules, approval review, security audits, and policy-check plugins._
 - [zhourenke/dsh-tool-call-limit](https://github.com/zhourenke/dsh-tool-call-limit) — DeepSeek Harness Cordis plugin that caps how many tool calls reach the DSH `ToolRuntime`, with independent quotas per live agent / turn / step / tool name, configured through a profile patch.
 - [mathangler/dsh-websearch-toggle](https://github.com/mathangler/dsh-websearch-toggle) — DeepSeek Harness plugin: a live on/off switch for the Web search settings card; turning it off withholds the web_search tool from every agent.
 - [snailium/dsh-repeat-tool-breaker](https://github.com/snailium/dsh-repeat-tool-breaker) — Hard break on repeated identical tool calls in DeepSeek Harness (DSH): a synchronous monotonic ctx.tools.guard gate that denies the 2nd identical call per agent. Dependency-free.
+- [jackeyunjie/dsh-rule-lens](https://github.com/jackeyunjie/dsh-rule-lens) — RuleScope Lens — DSH local plugin: AGENTS.md/rules load visualization, budget governance, hard interception, lint, and adherence rate.
 
 ## Session & Memory Management
 
@@ -1623,6 +1634,9 @@ _Cross-session memory, checkpoints, pinning, and session navigation plugins._
 - [AbcdefgXW/dsh-toolbox-web](https://github.com/AbcdefgXW/dsh-toolbox-web) — Toolbox plugin for dsh: session / trash / subdirectory / search / preset / config management, plus scheduled heartbeat and long-message collapse.
 - [Relethe/dsh-brief-session-title](https://github.com/Relethe/dsh-brief-session-title) — DSH session-title plugin: condenses a full sentence into a single word for easier recall.
 - [tzwkb/dsh-codex-import](https://github.com/tzwkb/dsh-codex-import) — DeepSeek Harness plugin: import Codex CLI/Desktop conversations as resumable dsh-tui sessions.
+- [dingguangyi0/dsh-plugin-migration-workbuddy](https://github.com/dingguangyi0/dsh-plugin-migration-workbuddy) — Migrate WorkBuddy sessions, memories, MCP drafts, and automation tasks into DSH — preview-first, read-only on the source.
+- [gausszhou/dsh-opencode-session-id](https://github.com/gausszhou/dsh-opencode-session-id) — dsh session IDs for opencode, zero config.
+- [guoxing2024/hippo-memory](https://github.com/guoxing2024/hippo-memory) — Hippocampus-inspired long-term memory for AI agents: engine (hippo-memory-core) + DSH plugin (dsh-hippo-memory). SQLite-local, zero external services.
 
 ## Cost & Usage Tracking
 
@@ -2351,6 +2365,7 @@ _Plugins that turn data / results into charts, diagrams, dashboards._
 - [acryldev/cordis-plugin-graph](https://github.com/acryldev/cordis-plugin-graph) — DSH/Cordis Web plugin: a zoomable relation graph of every loaded plugin (dependencies, resolved providers, Loader-tree nesting) as a Settings tab next to "Plugin list".
 - [huashenglian/dsh-omni-workstation](https://github.com/huashenglian/dsh-omni-workstation) — Any-to-Any multimodal workstation plugin for dsh: video, image and speech input/output for models, plus ComfyUI image-generation tool calls.
 - [RYANFFY/deepseek-dafeiyu-pet](https://github.com/RYANFFY/deepseek-dafeiyu-pet) — 🐋 DeepSeek Big-Fat-Fish desktop pet for Windows: wanders around, checks the weather, and watches your DeepSeek balance (balance / today's spend / peak & off-peak windows / per-turn consumption); drag-snap, flip on left edge, bouncy sound effects, rolling digits, custom avatars, app integration — the desktop-pet edition of the DSH whale balance widget. MIT.
+- [Limbo-137/dsh-typst-preview](https://github.com/Limbo-137/dsh-typst-preview) — Live Typst preview in the DeepSeek Harness Web UI's native right sidebar, rendered by a per-file tinymist preview server proxied over the app origin.
 ## Slides / PPT
 
 _Generate presentations, decks, slide exports._
@@ -4549,6 +4564,18 @@ _Desktop, web, terminal, or editor front-ends for DSH._
 - [xiaoyuink/dsh-workbench](https://github.com/xiaoyuink/dsh-workbench) — DSH Web plugin: registers file explorer / browser / real terminal / background tasks as official right-side Sidebar tabs (with Office/TIFF/HEIC/PSD preview and editing); older DSH builds fall back to a center column.
 - [aytacbilgisayar-hub/dsh-locale-tr](https://github.com/aytacbilgisayar-hub/dsh-locale-tr) — Turkish (Türkçe) language pack for DeepSeek Harness (dsh) — client plugin registering the tr UI locale.
 - [liutian11451-png/dsh-plugin-model-config](https://github.com/liutian11451-png/dsh-plugin-model-config) — Full model-configuration editor for the DeepSeek Harness web Settings → Models page: every field the deployment's model-config schema declares.
+- [Artenx/dsh-honeybee](https://github.com/Artenx/dsh-honeybee) — Cloud agent workbench built on deepseek-harness — start turning your ideas into reality anywhere.
+- [johnhom1024/dsh-loopback-bridge](https://github.com/johnhom1024/dsh-loopback-bridge) — Unlock DSH Web settings and credentials when you open the UI from a LAN IP or public hostname.
+- [kelai141/dsh-client-ui-responsive](https://github.com/kelai141/dsh-client-ui-responsive) — Mobile-responsive AppFrame for the dsh Web UI — derived from dsh-client-ui-layout, adding a drawer sidebar below 640px, a bottom sheet, and safe-area handling.
+- [lesliechowsh/dsh-weniger-theme](https://github.com/lesliechowsh/dsh-weniger-theme) — "Weniger" — less, but better: a Dieter Rams-inspired theme for the DeepSeek Harness Web GUI.
+- [omdsh-dev/dsh-gal](https://github.com/omdsh-dev/dsh-gal) — Galgame / visual-novel UI plugin for DeepSeek Harness: a whale-girl companion with animated expressions, scene-at-a-time dialogue, and an LLM emotion judge.
+- [Raylen-berry/dsh-browser-live](https://github.com/Raylen-berry/dsh-browser-live) — Visible agent browser (custom DSH plugin): 18 browser_* tools drive local Chrome/Edge (CDP + human-like mouse paths); the live view window works as an embedded panel or a standalone page, supports keyboard/mouse takeover, and takes a proxy plus extra launch args. The floating orb tucks under the mask while the settings page is open and the panel moves into its standalone page; login state persists in $DSH_HOME/dsh-browser-live.
+- [shuishuipingan/InkWeaver](https://github.com/shuishuipingan/InkWeaver) — 织墨 InkWeaver — local-first writing workspace for long-form fiction.
+- [sky1ine139/dsh-plugin-screenshot-ask](https://github.com/sky1ine139/dsh-plugin-screenshot-ask) — DSH screenshot-ask plugin: native region capture straight into the input box, never written to disk (DeepSeek Harness plugin, Windows).
+- [strawberry0321/dsh-gal](https://github.com/strawberry0321/dsh-gal) — dsh-gal — a DeepSeek Harness companion widget: live balance and today's spend, per-turn token/cost settlement, and a click on the art for random voice lines with typewriter text; both art packs and voice packs are swappable.
+- [xiaoshengliang2002/dsh-prompt-boost-pro](https://github.com/xiaoshengliang2002/dsh-prompt-boost-pro) — Enhance the composer draft before sending: a sparkle button in the DSH web GUI rewrites your prompt in structured or light mode, with an original-versus-enhanced preview.
+- [xp266/dsh-tui](https://github.com/xp266/dsh-tui) — ink-based terminal UI plugin for DeepSeek Harness.
+- [YuluoY/dsh-kujira](https://github.com/YuluoY/dsh-kujira) — Kujira: an animated DeepSeek Harness companion with live task progress, global off-peak scheduling, usage costs, and an extensible radial menu.
 
 ## Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -959,6 +959,16 @@ _DeepSeek 原生 / DeepSeek 优先的 agent harness、coding agent，以及运�
 - [andrepontesmelo/dsh-model-router](https://github.com/andrepontesmelo/dsh-model-router) — DSH 插件：用可插拔路由算法（优先级、轮询）把虚拟模型 id 映射到真实 provider 候选模型，并支持透明故障转移。
 - [twilightt1/dsh-llm-chatgpt-web](https://github.com/twilightt1/dsh-llm-chatgpt-web) — 把 ChatGPT 网页版作为 DeepSeek Harness 的 provider：自带 Chromium 守护进程驱动 Temporary Chat，无需 API key。
 - [SiriusWJ/dsh-restart-btn](https://github.com/SiriusWJ/dsh-restart-btn) — 设置页一键重启 dsh web 插件：复用桌面启动器机制（node + lib/bin.js、日志重定向、TCP 就绪轮询），修复非 ASCII 路径下计划任务静默失败的问题。
+- [bpc-oss/dsh-video-input-mod](https://github.com/bpc-oss/dsh-video-input-mod) —— DSH Desktop 的原生视频输入：内核补丁（P17-P25）、工具与文档。Agent 可直接从磁盘读取视频，按能力自动选择原生解码或抽帧。
+- [imMamdouhaboammar/get-fable](https://github.com/imMamdouhaboammar/get-fable) —— 让你手上的模型更像前沿模型：更好的规划、持久上下文、技能、hooks、失败处理与结果验证。
+- [jiale-li-orion/meshfin](https://github.com/jiale-li-orion/meshfin) —— 一个 Agent 横跨多台设备：基于 DeepSeek Harness 构建的多设备能力运行时与常驻 Agent 个人工作台。
+- [lengmoXXL/dsh-remote-ssh-worktree](https://github.com/lengmoXXL/dsh-remote-ssh-worktree) —— 通过 SSH 把 DSH 的文件、Shell 与终端工具放进远程机器的 git worktree 里运行；远端 Agent 以静态 Rust 二进制从 GitHub Releases 自装，监听随机回环端口，随插件一起更新。
+- [MurasakiIzumi/dsh-quake-alert](https://github.com/MurasakiIzumi/dsh-quake-alert) —— 面向 DeepSeek Harness（DSH）的日本实时地震、紧急地震速报（EEW）、海啸与 JMA 气象警报，按你关注的区域与阈值匹配。
+- [wly8691-jpg/dsh-office-com](https://github.com/wly8691-jpg/dsh-office-com) —— DSH 插件：通过 COM 驱动真正的 Office 自动化（VBA / 数据透视表 / 重算 / 排版）。
+- [xiaomao49/dsh-model-probe](https://github.com/xiaomao49/dsh-model-probe) —— DeepSeek Harness 插件：直接探测端点来审计并修正 llm-pi-ai 的模型能力声明（越界的 maxTokens、contextWindow、推理档位、图片输入）。
+- [Yinxe/deepseek-harness-plugins](https://github.com/Yinxe/deepseek-harness-plugins) —— DeepSeek Harness（DSH）插件 monorepo（pnpm + TypeScript）。
+- [Yunado/dsh-qwen38-local-qol](https://github.com/Yunado/dsh-qwen38-local-qol) —— 面向本地 Qwen3.8 线（27B/Flash-Next）的 DSH QoL 插件：逐请求 thinking 预算、不再把输出上限烧在 thinking 上的压缩后端，以及设置 tab。
+- [zhengjy01/dsh-restart](https://github.com/zhengjy01/dsh-restart) —— DeepSeek Harness 一键重启：网页按钮（外加 dsh_restart Agent 工具）把重启交给独立 helper，页面自动重连；新宿主启动失败时由恢复控制台显示启动错误。
 
 ## 安全与权限
 
@@ -1170,6 +1180,7 @@ _权限规则、审批复核、安全审计与调用前 policy-check 插件。_
 - [zhourenke/dsh-tool-call-limit](https://github.com/zhourenke/dsh-tool-call-limit) —— DeepSeek Harness 的 Cordis 插件，限制进入 DSH `ToolRuntime` 的工具调用次数：按 live Agent / turn / step / 工具名分别配额，通过 profile patch 配置。
 - [mathangler/dsh-websearch-toggle](https://github.com/mathangler/dsh-websearch-toggle) —— DeepSeek Harness 插件：给 Web 搜索设置卡加一个实时开关；关掉之后对所有 agent 都不再下发 web_search 工具。
 - [snailium/dsh-repeat-tool-breaker](https://github.com/snailium/dsh-repeat-tool-breaker) —— DeepSeek Harness（DSH）重复工具调用硬熔断：一个同步单调的 ctx.tools.guard 门，对每个 agent 拒绝第 2 次完全相同的调用。零依赖。
+- [jackeyunjie/dsh-rule-lens](https://github.com/jackeyunjie/dsh-rule-lens) —— 规则透镜（RuleScope Lens）——DSH 本地插件：AGENTS.md/rules 加载可视化、预算治理、硬拦截、Lint 与遵守率统计。
 
 ## 会话与记忆管理
 
@@ -1628,6 +1639,9 @@ _跨会话记忆、checkpoint、会话置顶与导航插件。_
 - [AbcdefgXW/dsh-toolbox-web](https://github.com/AbcdefgXW/dsh-toolbox-web) —— dsh 工具箱：会话 / 回收站 / 子目录 / 搜索 / 预设 / 配置管理，外加定时心跳与长消息折叠。
 - [Relethe/dsh-brief-session-title](https://github.com/Relethe/dsh-brief-session-title) — DSH 会话标题插件：把一整句话浓缩成一个词，方便回忆与查找。
 - [tzwkb/dsh-codex-import](https://github.com/tzwkb/dsh-codex-import) — DeepSeek Harness 插件：把 Codex CLI / 桌面版会话导入为可继续的 dsh-tui 会话。
+- [dingguangyi0/dsh-plugin-migration-workbuddy](https://github.com/dingguangyi0/dsh-plugin-migration-workbuddy) —— 把 WorkBuddy 的会话、记忆、MCP 草稿与自动化任务迁移进 DSH：预览优先，对源端只读。
+- [gausszhou/dsh-opencode-session-id](https://github.com/gausszhou/dsh-opencode-session-id) —— 为 opencode 提供 dsh session ID，零配置。
+- [guoxing2024/hippo-memory](https://github.com/guoxing2024/hippo-memory) —— 受海马体启发的 AI Agent 长期记忆：引擎（hippo-memory-core）+ DSH 插件（dsh-hippo-memory），本地 SQLite，零外部服务。
 
 ## 成本与用量统计
 
@@ -2361,6 +2375,7 @@ _把数据 / 结果变成图表、图形、看板的插件。_
 - [acryldev/cordis-plugin-graph](https://github.com/acryldev/cordis-plugin-graph) — DSH/Cordis Web 插件：在“插件列表”旁的 Settings 标签中展示所有已加载插件的可缩放关系图（依赖、已解析 provider、Loader 树嵌套）。
 - [huashenglian/dsh-omni-workstation](https://github.com/huashenglian/dsh-omni-workstation) —— dsh 全模态工作站插件：让模型支持视频、图片、语音的输入与输出，并支持 ComfyUI 图像生成工具调用。Any-to-Any。
 - [RYANFFY/deepseek-dafeiyu-pet](https://github.com/RYANFFY/deepseek-dafeiyu-pet) — 🐋 DeepSeek 大肥鱼桌宠 · Windows 独立桌面宠物：会散步、查天气，并盯着你的 DeepSeek 余额——余额 / 今日已用 / 峰谷时段 / 每轮消耗统计；拖拽吸附、左吸附翻面、Q弹音效、数字滚动、自定义形象、应用联动。DSH 同款小鲸鱼余额挂件的桌宠版，MIT 开源。
+- [Limbo-137/dsh-typst-preview](https://github.com/Limbo-137/dsh-typst-preview) —— 在 DeepSeek Harness Web UI 原生右侧栏里实时预览 Typst，由按文件启动的 tinymist 预览服务经应用同源代理渲染。
 ## 幻灯片 / PPT
 
 _生成演示文稿、幻灯片、导出 PPT。_
@@ -4549,6 +4564,18 @@ _DSH 的桌面、网页、终端或编辑器前端。_
 - [xiaoyuink/dsh-workbench](https://github.com/xiaoyuink/dsh-workbench) —— DSH Web 插件：把资源管理器 / 浏览器 / 真实终端 / 后台任务注册成官方右侧 Sidebar 标签页（含 Office/TIFF/HEIC/PSD 预览与编辑）；旧 DSH 自动回退中部栏。
 - [aytacbilgisayar-hub/dsh-locale-tr](https://github.com/aytacbilgisayar-hub/dsh-locale-tr) — DeepSeek Harness 土耳其语（Türkçe）语言包 —— 注册 tr UI locale 的客户端插件。
 - [liutian11451-png/dsh-plugin-model-config](https://github.com/liutian11451-png/dsh-plugin-model-config) — DeepSeek Harness 网页版「设置 → 模型」页的完整模型配置编辑器：覆盖部署方 model-config schema 声明的每一个字段。
+- [Artenx/dsh-honeybee](https://github.com/Artenx/dsh-honeybee) —— 基于 deepseek-harness 的云端 Agent 工作台，随时随地开始实现你的想法。
+- [johnhom1024/dsh-loopback-bridge](https://github.com/johnhom1024/dsh-loopback-bridge) —— 当你通过局域网 IP 或公网域名打开 DSH Web UI 时，解锁设置与凭证相关能力。
+- [kelai141/dsh-client-ui-responsive](https://github.com/kelai141/dsh-client-ui-responsive) —— dsh Web UI 的移动响应式 AppFrame：派生自 dsh-client-ui-layout，新增 <640px 抽屉侧栏、底部 sheet 与安全区适配。
+- [lesliechowsh/dsh-weniger-theme](https://github.com/lesliechowsh/dsh-weniger-theme) —— "Weniger"——少即是好：受 Dieter Rams 启发的 DeepSeek Harness Web GUI 主题。
+- [omdsh-dev/dsh-gal](https://github.com/omdsh-dev/dsh-gal) —— DeepSeek Harness 的 Galgame / 视觉小说 UI 插件：鲸娘立绘伴侣、表情动画、逐场景对话与 LLM 情绪判定。
+- [Raylen-berry/dsh-browser-live](https://github.com/Raylen-berry/dsh-browser-live) —— 看得见的 Agent 浏览器（自研 DSH 插件）：18 个 browser_* 工具直接驱动本机 Chrome/Edge（CDP + 拟人鼠标轨迹）；实时观察窗支持内嵌面板与独立网页两态、可键鼠接管、可配代理与额外启动参数；设置页开着时浮球沉到遮罩底下、面板自动收进独立网页；登录态持久化在 $DSH_HOME/dsh-browser-live。
+- [shuishuipingan/InkWeaver](https://github.com/shuishuipingan/InkWeaver) —— 织墨 InkWeaver——面向长篇小说的本地优先写作工作区。
+- [sky1ine139/dsh-plugin-screenshot-ask](https://github.com/sky1ine139/dsh-plugin-screenshot-ask) —— DSH 截图提问插件：原生框选截图直接进输入框，全程不落盘（DeepSeek Harness 插件，Windows）。
+- [strawberry0321/dsh-gal](https://github.com/strawberry0321/dsh-gal) —— dsh-gal——DeepSeek Harness 立绘挂件：实时显示余额与今日消耗、每轮对话结束结算 token 与花费、点击立绘随机播语音并逐字显示台词，立绘包/语音包都能换。
+- [xiaoshengliang2002/dsh-prompt-boost-pro](https://github.com/xiaoshengliang2002/dsh-prompt-boost-pro) —— 发送前增强草稿：DSH Web GUI 里的闪光按钮可按结构化或轻量模式重写你的 prompt，并提供原文与增强版对照预览。
+- [xp266/dsh-tui](https://github.com/xp266/dsh-tui) —— 基于 ink 的 DeepSeek Harness 终端 UI 插件。
+- [YuluoY/dsh-kujira](https://github.com/YuluoY/dsh-kujira) —— Kujira：DeepSeek Harness 动画伙伴，含实时任务进度、全局错峰调度、用量费用与可扩展径向菜单。
 
 ## Skill
 


### PR DESCRIPTION
自动扫描收录：新增 27 条社区 DSH 插件（去重后）。仅改 README.md / README.zh-CN.md。由每日扫描自动化生成，PR 巡检会自动核验链接真实性与格式后合并。